### PR TITLE
LPS-120972 Avoid show the list table when receiving empty items

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/list-view/ListView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/list-view/ListView.es.js
@@ -113,7 +113,7 @@ export default withRouter(
 		}
 
 		const selectedFilters = getSelectedFilters(filters, query.filters);
-		const isEmpty = totalCount === 0;
+		const isEmpty = totalCount === 0 || items.length === 0;
 		const isFiltered = selectedFilters.length > 0;
 
 		return (


### PR DESCRIPTION
This is a workaround to avoid showing the list table when the fetch response looks like this:
`{ ... , items: [], ... , totalCount: 1 }`