### PR TITLE
LPS-120644 Add property key to children components

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPage.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-list-page/ProcessListPage.es.js
@@ -54,7 +54,7 @@ const ProcessListPage = ({history, query, routeParams}) => {
 	usePageTitle(Liferay.Language.get('metrics'));
 
 	const {page, pageSize, sort} = routeParams;
-	const {search = null} = parse(query);
+	const {search = ''} = parse(query);
 
 	const {data, fetchData} = useFetch({
 		params: {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
@@ -12,7 +12,7 @@
 import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import {useFetch} from '../../../shared/hooks/useFetch.es';
 import {useFilter} from '../../../shared/hooks/useFilter.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCardBody.es.js
@@ -11,9 +11,9 @@
 
 import React from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import {formatNumber} from '../../../shared/util/numeral.es';
 import VelocityChart from './VelocityChart.es';
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
@@ -12,7 +12,7 @@
 import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import {useFilter} from '../../../shared/hooks/useFilter.es';
 import {usePost} from '../../../shared/hooks/usePost.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCardBody.es.js
@@ -12,9 +12,9 @@
 import ClayIcon from '@clayui/icon';
 import React, {useContext, useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import ChildLink from '../../../shared/components/router/ChildLink.es';
 import {AppContext} from '../../AppContext.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
@@ -12,7 +12,7 @@
 import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import {useFetch} from '../../../shared/hooks/useFetch.es';
 import {useFilter} from '../../../shared/hooks/useFilter.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCardBody.es.js
@@ -12,9 +12,9 @@
 import ClayIcon from '@clayui/icon';
 import React, {useContext} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import ChildLink from '../../../shared/components/router/ChildLink.es';
 import {AppContext} from '../../AppContext.es';
 import {Table} from './PerformanceByStepCardTable.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
@@ -15,9 +15,9 @@ import ClayLayout from '@clayui/layout';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import {useFetch} from '../../../shared/hooks/useFetch.es';
 import PANELS from './Panels.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCard.es.js
@@ -11,7 +11,7 @@
 
 import React, {useMemo, useState} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import Tabs from '../../../shared/components/tabs/Tabs.es';
 import {useFilter} from '../../../shared/hooks/useFilter.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCardBody.es.js
@@ -12,9 +12,9 @@
 import ClayIcon from '@clayui/icon';
 import React, {useContext, useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import ChildLink from '../../../shared/components/router/ChildLink.es';
 import {AppContext} from '../../AppContext.es';
 import {Table} from './WorkloadByAssigneeCardTable.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
@@ -12,7 +12,7 @@
 import ClayLayout from '@clayui/layout';
 import React, {useMemo} from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import PromisesResolver from '../../../shared/components/promises-resolver/PromisesResolver.es';
 import {useFetch} from '../../../shared/hooks/useFetch.es';
 import {Body} from './WorkloadByStepCardBody.es';

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCardBody.es.js
@@ -11,10 +11,10 @@
 
 import React from 'react';
 
-import Panel from '../../../shared/components/Panel.es';
 import ContentView from '../../../shared/components/content-view/ContentView.es';
 import ReloadButton from '../../../shared/components/list/ReloadButton.es';
 import PaginationBar from '../../../shared/components/pagination-bar/PaginationBar.es';
+import Panel from '../../../shared/components/panel/Panel.es';
 import {Table} from './WorkloadByStepCardTable.es';
 
 const Body = ({items, page, pageSize, processId, totalCount}) => {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/hooks/useSLAFormState.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/form-page/hooks/useSLAFormState.es.js
@@ -24,7 +24,7 @@ import {START_NODE_KEYS, STOP_NODE_KEYS} from '../SLAFormConstants.es';
 const useSLAFormState = ({errors, id, processId, setErrors}) => {
 	const [sla, setSLA] = useState({
 		calendarKey: null,
-		days: null,
+		days: '',
 		description: '',
 		hours: '',
 		name: '',

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/autocomplete/AutocompleteMultiSelect.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/autocomplete/AutocompleteMultiSelect.es.js
@@ -198,9 +198,9 @@ const AutocompleteMultiSelect = ({
 	);
 };
 
-const Item = ({key, name, onRemove}) => {
+const Item = ({name, onRemove}) => {
 	return (
-		<span className="label label-dismissible label-secondary" key={key}>
+		<span className="label label-dismissible label-secondary">
 			<span className="label-item label-item-expand">{name}</span>
 
 			<span className="label-item label-item-after">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/Filter.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/Filter.es.js
@@ -45,7 +45,6 @@ const Filter = ({
 	prefixKey = '',
 	preventClick,
 	withoutRouteParams,
-	...otherProps
 }) => {
 	const {dispatchFilter} = useFilter({withoutRouteParams});
 	const [expanded, setExpanded] = useState(false);
@@ -184,7 +183,7 @@ const Filter = ({
 	}, [applyFilterChanges, expanded, changed]);
 
 	return (
-		<li className={classes.dropdown} ref={wrapperRef} {...otherProps}>
+		<li className={classes.dropdown} ref={wrapperRef}>
 			<button
 				className={classes.custom}
 				disabled={disabled}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/FilterItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/FilterItem.es.js
@@ -59,6 +59,7 @@ const FilterItem = ({
 					<input
 						checked={checked}
 						className="custom-control-input"
+						onChange={onClickFilter}
 						type={multiple ? 'checkbox' : 'radio'}
 					/>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/panel/Panel.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/panel/Panel.es.js
@@ -62,7 +62,7 @@ const HeaderWithOptions = ({
 	return (
 		<Header elementClasses={elementClasses}>
 			<ClayLayout.ContentRow>
-				<ClayLayout.ContentRow className="flex-row" expand>
+				<ClayLayout.ContentRow className="flex-row" expand="true">
 					<span className="mr-2">{title}</span>
 
 					<ClayTooltipProvider>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/search-field/SearchField.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/search-field/SearchField.es.js
@@ -25,9 +25,9 @@ const SearchField = ({
 	const routerProps = useRouter();
 
 	const query = parse(routerProps.location.search);
-	const {search = null} = query;
+	const {search = ''} = query;
 
-	const [searchValue, setSearchValue] = useState(null);
+	const [searchValue, setSearchValue] = useState('');
 
 	useEffect(() => {
 		setSearchValue(search);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/mock/MockRouter.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/mock/MockRouter.es.js
@@ -21,7 +21,7 @@ const withParamsMock = (...components) => ({
 	location: {search: query},
 	match: {params: routeParams},
 }) => {
-	return components.map((component) => {
+	return components.map((component, key) => {
 		if (routeParams.sort) {
 			routeParams.sort = decodeURIComponent(routeParams.sort);
 		}
@@ -29,6 +29,7 @@ const withParamsMock = (...components) => ({
 		return cloneElement(component, {
 			...routeParams,
 			history,
+			key,
 			query,
 			routeParams,
 		});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/shared/components/panel/Panel.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/shared/components/panel/Panel.es.js
@@ -14,7 +14,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-import Panel from '../../../src/main/resources/META-INF/resources/js/shared/components/Panel.es';
+import Panel from '../../../../src/main/resources/META-INF/resources/js/shared/components/panel/Panel.es';
 
 describe('The Panel component should', () => {
 	afterEach(cleanup);


### PR DESCRIPTION
Removing some of react warnings when running tests. Some similar warnings remain that require changes on several tests, adding the `act()` method for interactions such as click, change and others. I'll do this on another PR.

The remaining warnings look like this:
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */`
