### PR TITLE
LPS-122477 Fix redirect after assigning workflow task to self

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
@@ -78,7 +78,7 @@ redirectURL.setParameter("mvcPath", "/view.jsp");
 			<c:otherwise>
 				<liferay-portlet:renderURL copyCurrentRenderParameters="<%= false %>" var="assignToMeURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 					<portlet:param name="mvcPath" value="/workflow_task_assign.jsp" />
-					<portlet:param name="redirect" value="<%= currentURL %>" />
+					<portlet:param name="redirect" value="<%= redirectURL.toString() %>" />
 					<portlet:param name="workflowTaskId" value="<%= String.valueOf(workflowTask.getWorkflowTaskId()) %>" />
 					<portlet:param name="assigneeUserId" value="<%= String.valueOf(user.getUserId()) %>" />
 				</liferay-portlet:renderURL>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122477

Notes from @noornajj 
> The issue was the page was not redirecting to the Assigned to Me tab after assigning a workflow task to self.
> I fixed this issue by changing the redirect value in workflow_task_action.jsp from currentURL to redirectURL.toString().