### PR TITLE
LPS-122763 Remove deprecated class usage

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarBookingStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarBookingStagedModelDataHandler.java
@@ -20,7 +20,7 @@ import com.liferay.calendar.model.Calendar;
 import com.liferay.calendar.model.CalendarBooking;
 import com.liferay.calendar.service.CalendarBookingLocalService;
 import com.liferay.calendar.workflow.constants.CalendarBookingWorkflowConstants;
-import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
+import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarResourceStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarResourceStagedModelDataHandler.java
@@ -20,7 +20,7 @@ import com.liferay.calendar.model.Calendar;
 import com.liferay.calendar.model.CalendarResource;
 import com.liferay.calendar.service.CalendarLocalService;
 import com.liferay.calendar.service.CalendarResourceLocalService;
-import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
+import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
@@ -18,7 +18,7 @@ import com.liferay.calendar.constants.CalendarPortletKeys;
 import com.liferay.calendar.model.Calendar;
 import com.liferay.calendar.model.CalendarResource;
 import com.liferay.calendar.service.CalendarLocalService;
-import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
+import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

`com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler`, as opposed to `com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler` adds the IDs of the `ChangesetEntries` to `ChangesetThreadLocal` during export in it's `exportStagedModel` method, so the `ChangesetEntries` will be deleted after publication.

This is necessary for the Export-Import portlet to detect that no `Calendars`, `CalendarResources` and `CalendarBookings` have been added/changed/deleted since the last publish date.

Thank you and best regards,
István