### PR TITLE
[TS] LPS-129410

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/util/CalendarICalDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/util/CalendarICalDataHandler.java
@@ -676,24 +676,26 @@ public class CalendarICalDataHandler implements CalendarDataHandler {
 		Company company = CompanyLocalServiceUtil.getCompany(
 			calendarBooking.getCompanyId());
 
+		String calendarBookingDescriptionText = StringUtil.replace(
+			calendarBooking.getDescription(user.getLocale()),
+			new String[] {"href=\"/", "src=\"/"},
+			new String[] {
+				"href=\"" +
+					company.getPortalURL(calendarBooking.getGroupId()) +
+						"/",
+				"src=\"" +
+					company.getPortalURL(calendarBooking.getGroupId()) + "/"
+			});
+
 		String calendarBookingDescription = HtmlUtil.stripHtml(
-			StringUtil.replace(
-				calendarBooking.getDescription(user.getLocale()),
-				new String[] {"href=\"/", "src=\"/"},
-				new String[] {
-					"href=\"" +
-						company.getPortalURL(calendarBooking.getGroupId()) +
-							"/",
-					"src=\"" +
-						company.getPortalURL(calendarBooking.getGroupId()) + "/"
-				}));
+			calendarBookingDescriptionText);
 
 		Description description = new Description(calendarBookingDescription);
 
 		propertyList.add(description);
 
 		XProperty xProperty = new XProperty(
-			"X-ALT-DESC", calendarBookingDescription);
+			"X-ALT-DESC", calendarBookingDescriptionText);
 
 		ParameterList parameters = xProperty.getParameters();
 


### PR DESCRIPTION
The source formatting commit of LPS-20825 made it so that the same description string is used in both the DESCRIPTION and X-ALT-DESC properties - https://github.com/brianchandotcom/liferay-portal/pull/83640/commits/e5e3954fa429164117d9df6f2f9653e28872bd83

The X-ALT-DESC property is allowed to contain HTML so this fix partially reverts LPS-20825 to allow this.

Please let me know if there are any questions.