### PR TITLE
LPS-133084 Calendar event title gets shortened to 75 characters in event edit mode

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/calendar/calendar-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -40,7 +40,9 @@
 		<field name="vEventUid" type="String">
 			<hint name="max-length">255</hint>
 		</field>
-		<field localized="true" name="title" type="String" />
+		<field localized="true" name="title" type="String">
+			<hint name="max-length">4000</hint>
+		</field>
 		<field localized="true" name="description" type="String">
 			<hint-collection name="EDITOR" />
 		</field>


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Thank you and best regards,
István