### PR TITLE
[TS] LPS-133327 | Possible unique constraint violation IX_228562AD for WorkflowMetricsIndexCreator having more than one virtual instance

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
@@ -59,7 +59,7 @@ public class WorkflowMetricsReindexBackgroundTaskExecutor
 	public WorkflowMetricsReindexBackgroundTaskExecutor() {
 		setBackgroundTaskStatusMessageTranslator(
 			new WorkflowMetricsReindexBackgroundTaskStatusMessageTranslator());
-		setIsolationLevel(BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME);
+		setIsolationLevel(BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY);
 	}
 
 	@Override


### PR DESCRIPTION
Hi @liferay-workflow,

This pr solves [LPS-133327](https://issues.liferay.com/browse/LPS-133327), which produces some error traces in the logs due to an index violation for the table _Lock__ due to background tasks invoked by `WorkflowMetricsIndexCreator` not discriminating by `companyId` (when there are at least to virtual instances).

Please let me know if you have any questions. 

Thanks!