### PR TITLE
LPS-132436 Migrate dynamic data structure selection modals

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
@@ -345,31 +345,58 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 	</aui:button-row>
 </clay:container-fluid>
 
+<%
+Portlet portlet = PortletLocalServiceUtil.getPortletById(portletDisplay.getId());
+
+String itemSelectorURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, PortletRequest.RENDER_PHASE)
+).setMVCPath(
+	"/select_structure.jsp"
+).setParameter(
+	"classNameId", PortalUtil.getClassNameId(DDMStructure.class)
+).setParameter(
+	"classPK", (structure != null) ? structure.getPrimaryKey() : 0
+).setParameter(
+	"groupId", groupId
+).setParameter(
+	"navigationStartsOn", DDMNavigationHelper.EDIT_STRUCTURE
+).setParameter(
+	"portletResourceNamespace", liferayPortletResponse.getNamespace()
+).setParameter(
+	"refererPortletName", refererPortletName
+).setParameter(
+	"showAncestorScopes", true
+).setParameter(
+	"showBackURL", false
+).setParameter(
+	"showHeader", false
+).setParameter(
+	"showManageTemplates", false
+).setParameter(
+	"structureAvailableFields", liferayPortletResponse.getNamespace() + "getAvailableFields"
+).setWindowState(
+	LiferayWindowState.POP_UP
+).buildString();
+%>
+
 <aui:script>
 	function <portlet:namespace />openParentStructureSelector() {
-		Liferay.Util.openDDMPortlet(
-			{
-				basePortletURL:
-					'<%= PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, PortletRequest.RENDER_PHASE) %>',
-				classPK: <%= (structure != null) ? structure.getPrimaryKey() : 0 %>,
-				dialog: {
-					destroyOnHide: true,
-				},
-				eventName: '<portlet:namespace />selectParentStructure',
-				mvcPath: '/select_structure.jsp',
-				showAncestorScopes: true,
-				showManageTemplates: false,
-				title: '<%= HtmlUtil.escapeJS(scopeTitle) %>',
-			},
-			(event) => {
-				var form = document.<portlet:namespace />fm;
+		const opener = Liferay.Util.getOpener();
+
+		opener.Liferay.Util.openSelectionModal({
+			onSelect: function (selectedItem) {
+				const form = document.<portlet:namespace />fm;
+
+				if (!form) {
+					return;
+				}
 
 				Liferay.Util.setFormValues(form, {
-					parentStructureId: event.ddmstructureid,
-					parentStructureName: Liferay.Util.unescape(event.name),
+					parentStructureId: selectedItem.ddmstructureid,
+					parentStructureName: Liferay.Util.unescape(selectedItem.name),
 				});
 
-				var removeParentStructureButton = Liferay.Util.getFormElement(
+				const removeParentStructureButton = Liferay.Util.getFormElement(
 					form,
 					'removeParentStructureButton'
 				);
@@ -377,19 +404,26 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 				if (removeParentStructureButton) {
 					Liferay.Util.toggleDisabled(removeParentStructureButton, false);
 				}
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectParentStructure',
+			title: '<%= HtmlUtil.escapeJS(scopeTitle) %>',
+			url: '<%= itemSelectorURL %>',
+		});
 	}
 
 	function <portlet:namespace />removeParentStructure() {
-		var form = document.<portlet:namespace />fm;
+		const form = document.<portlet:namespace />fm;
+
+		if (!form) {
+			return;
+		}
 
 		Liferay.Util.setFormValues(form, {
 			parentStructureId: '',
 			parentStructureName: '',
 		});
 
-		var removeParentStructureButton = Liferay.Util.getFormElement(
+		const removeParentStructureButton = Liferay.Util.getFormElement(
 			form,
 			'removeParentStructureButton'
 		);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
@@ -200,11 +200,11 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 
 			var WIN = A.config.win;
 
-			Liferay.Util.openWindow({
+			Liferay.Util.openModal({
 				id: A.guid(),
 				refreshWindow: WIN,
 				title: title,
-				uri: uri,
+				url: uri,
 			});
 		},
 		['liferay-util']


### PR DESCRIPTION
Hey @liferay-workflow!

This is a part of [an ongoing epic](https://issues.liferay.com/browse/LPS-129246) to replace legacy AUI-based modals with Clay/React-based `openSelectionModal`. We have previously migrated DDM modals, in #407, but we were not aware of `openDDMPortlet` utilily. This PR is a 2nd part of the task that migrates `openDDMPortlet` related to `structure`, similar to what is being done with `template` in #454.

I have had to migrate `openWindow` to `openModal` in order to maintain the behaviour of opening modal on top of modal, instead of one inside the other.

# 🧪 Testing
1. Run `ant setup-profile-dxp` before `ant all` to gain access to Kaleo Forms Admin
2. Content & Data > Kaleo Forms Admin
3. Create a new Process
4. On the Fields step click on `Add Fields Step` & click on `Parent Field Set` under `Details`