### PR TITLE
LPS-132436 Migrate dynamic data structure selection modals

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_structure.jsp
@@ -345,31 +345,58 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 	</aui:button-row>
 </clay:container-fluid>
 
+<%
+Portlet portlet = PortletLocalServiceUtil.getPortletById(portletDisplay.getId());
+
+String itemSelectorURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, PortletRequest.RENDER_PHASE)
+).setMVCPath(
+	"/select_structure.jsp"
+).setParameter(
+	"classNameId", PortalUtil.getClassNameId(DDMStructure.class)
+).setParameter(
+	"classPK", (structure != null) ? structure.getPrimaryKey() : 0
+).setParameter(
+	"groupId", groupId
+).setParameter(
+	"navigationStartsOn", DDMNavigationHelper.EDIT_STRUCTURE
+).setParameter(
+	"portletResourceNamespace", liferayPortletResponse.getNamespace()
+).setParameter(
+	"refererPortletName", refererPortletName
+).setParameter(
+	"showAncestorScopes", true
+).setParameter(
+	"showBackURL", false
+).setParameter(
+	"showHeader", false
+).setParameter(
+	"showManageTemplates", false
+).setParameter(
+	"structureAvailableFields", liferayPortletResponse.getNamespace() + "getAvailableFields"
+).setWindowState(
+	LiferayWindowState.POP_UP
+).buildString();
+%>
+
 <aui:script>
 	function <portlet:namespace />openParentStructureSelector() {
-		Liferay.Util.openDDMPortlet(
-			{
-				basePortletURL:
-					'<%= PortletURLFactoryUtil.create(request, DDMPortletKeys.DYNAMIC_DATA_MAPPING, PortletRequest.RENDER_PHASE) %>',
-				classPK: <%= (structure != null) ? structure.getPrimaryKey() : 0 %>,
-				dialog: {
-					destroyOnHide: true,
-				},
-				eventName: '<portlet:namespace />selectParentStructure',
-				mvcPath: '/select_structure.jsp',
-				showAncestorScopes: true,
-				showManageTemplates: false,
-				title: '<%= HtmlUtil.escapeJS(scopeTitle) %>',
-			},
-			(event) => {
-				var form = document.<portlet:namespace />fm;
+		const opener = Liferay.Util.getOpener();
+
+		opener.Liferay.Util.openSelectionModal({
+			onSelect: function (selectedItem) {
+				const form = document.<portlet:namespace />fm;
+
+				if (!form) {
+					return;
+				}
 
 				Liferay.Util.setFormValues(form, {
-					parentStructureId: event.ddmstructureid,
-					parentStructureName: Liferay.Util.unescape(event.name),
+					parentStructureId: selectedItem.ddmstructureid,
+					parentStructureName: Liferay.Util.unescape(selectedItem.name),
 				});
 
-				var removeParentStructureButton = Liferay.Util.getFormElement(
+				const removeParentStructureButton = Liferay.Util.getFormElement(
 					form,
 					'removeParentStructureButton'
 				);
@@ -377,19 +404,26 @@ if (Validator.isNotNull(requestUpdateStructureURL)) {
 				if (removeParentStructureButton) {
 					Liferay.Util.toggleDisabled(removeParentStructureButton, false);
 				}
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectParentStructure',
+			title: '<%= HtmlUtil.escapeJS(scopeTitle) %>',
+			url: '<%= itemSelectorURL %>',
+		});
 	}
 
 	function <portlet:namespace />removeParentStructure() {
-		var form = document.<portlet:namespace />fm;
+		const form = document.<portlet:namespace />fm;
+
+		if (!form) {
+			return;
+		}
 
 		Liferay.Util.setFormValues(form, {
 			parentStructureId: '',
 			parentStructureName: '',
 		});
 
-		var removeParentStructureButton = Liferay.Util.getFormElement(
+		const removeParentStructureButton = Liferay.Util.getFormElement(
 			form,
 			'removeParentStructureButton'
 		);

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
@@ -924,8 +924,6 @@ definition {
 
 		Alert.viewSuccessMessageText(successMessage = "Definition imported successfully.");
 
-		Alert.closeMessage(messageType = "SUCCESS");
-
 		PortletEntry.publish();
 
 		AssertTextEquals.assertPartialText(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/macros/KaleoFormsAdmin.macro
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/macros/KaleoFormsAdmin.macro
@@ -17,12 +17,6 @@ definition {
 				locator1 = "KaleoFormsAdminEditProcess#ADD_FIELD_SET_BUTTON",
 				value1 = "Add Field Set");
 
-			var key_iframeTitle = "Field Set";
-
-			AssertTextEquals(
-				locator1 = "IFrame#IFRAME_TITLE",
-				value1 = "New Field Set");
-
 			SelectFrame(locator1 = "IFrame#MODAL_BODY");
 
 			PortletEntry.inputName(name = "${kfFieldSetName}");
@@ -172,6 +166,8 @@ definition {
 			kfProgressName = "Workflow",
 			kfProgressStep = "3");
 
+		Refresh();
+
 		if ("${kfPendingForm}" == "true") {
 			AssertTextEquals(
 				locator1 = "Message#INFO",
@@ -316,12 +312,6 @@ definition {
 		LexiconEntry.gotoEntryMenuItem(
 			menuItem = "Edit",
 			rowEntry = "${kfFieldSetName}");
-
-		var key_iframeTitle = "Field Set";
-
-		AssertTextEquals(
-			locator1 = "IFrame#IFRAME_TITLE",
-			value1 = "Edit Field Set");
 
 		SelectFrame(locator1 = "IFrame#MODAL_BODY");
 
@@ -535,7 +525,7 @@ definition {
 		SelectFrame(value1 = "relative=top");
 
 		if (IsElementPresent(locator1 = "IFrame#MODAL_BODY")) {
-			Click(locator1 = "Icon#CLOSE");
+			Click(locator1 = "KaleoFormsAdmin#CLOSE_BUTTON");
 		}
 
 		WaitForLiferayEvent.initializeLiferayEventLog();
@@ -567,6 +557,8 @@ definition {
 		KaleoFormsAdmin.viewNewProcessProgressBar(
 			kfProgressName = "Forms",
 			kfProgressStep = "4");
+
+		Refresh();
 
 		AssertElementNotPresent(locator1 = "Button#SAVE_INACTIVE");
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/tests/CPKaleoformsadmin.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/tests/CPKaleoformsadmin.testcase
@@ -594,14 +594,6 @@ definition {
 			category = "Content &amp; Data",
 			portlet = "Kaleo Forms Admin");
 
-		KaleoFormsAdmin.addProcess();
-
-		KaleoFormsAdmin.addProcessDetails(
-			kfProcessDescription = "${kfProcessDescription}",
-			kfProcessName = "${kfProcessName}");
-
-		KaleoFormsAdmin.next();
-
 		KaleoFormsAdmin.addFieldSet(
 			kfFieldSetName = "${kfFieldSetName}",
 			kfProcessName = "${kfProcessName}");
@@ -612,6 +604,14 @@ definition {
 			fieldName = "Boolean");
 
 		KaleoFormsAdmin.saveFieldSet();
+
+		KaleoFormsAdmin.addProcess();
+
+		KaleoFormsAdmin.addProcessDetails(
+			kfProcessDescription = "${kfProcessDescription}",
+			kfProcessName = "${kfProcessName}");
+
+		KaleoFormsAdmin.next();
 
 		KaleoFormsAdmin.chooseFieldSet(
 			kfFieldSetName = "${kfFieldSetName}",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsEditSingleApprover.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsEditSingleApprover.testcase
@@ -20,14 +20,6 @@ definition {
 			category = "Content &amp; Data",
 			portlet = "Kaleo Forms Admin");
 
-		KaleoFormsAdmin.addProcess();
-
-		KaleoFormsAdmin.addProcessDetails(
-			kfProcessDescription = "Kaleo Forms Process Description",
-			kfProcessName = "Kaleo Forms Process");
-
-		KaleoFormsAdmin.next();
-
 		KaleoFormsAdmin.addFieldSet(
 			kfFieldSetName = "${kfFieldSetName}",
 			kfProcessName = "Kaleo Forms Process");
@@ -38,6 +30,14 @@ definition {
 			fieldName = "Text");
 
 		KaleoFormsAdmin.saveFieldSet();
+
+		KaleoFormsAdmin.addProcess();
+
+		KaleoFormsAdmin.addProcessDetails(
+			kfProcessDescription = "Kaleo Forms Process Description",
+			kfProcessName = "Kaleo Forms Process");
+
+		KaleoFormsAdmin.next();
 
 		KaleoFormsAdmin.chooseFieldSet(
 			kfFieldSetName = "${kfFieldSetName}",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
@@ -200,11 +200,11 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 
 			var WIN = A.config.win;
 
-			Liferay.Util.openWindow({
+			Liferay.Util.openModal({
 				id: A.guid(),
 				refreshWindow: WIN,
 				title: title,
-				uri: uri,
+				url: uri,
 			});
 		},
 		['liferay-util']

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLDataDefinition.macro
@@ -319,9 +319,16 @@ definition {
 
 		var key_iframeTitle = "${assetTitle}";
 
-		AssertTextEquals(
-			locator1 = "IFrame#IFRAME_TITLE",
-			value1 = "${assetTitle}");
+		if (IsElementNotPresent(locator1 = "IFrame#IFRAME_TITLE")) {
+			AssertTextEquals(
+				locator1 = "Modal#HEADER",
+				value1 = "${assetTitle}");
+		}
+		else {
+			AssertTextEquals(
+				locator1 = "IFrame#IFRAME_TITLE",
+				value1 = "${assetTitle}");
+		}
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
@@ -10,7 +10,7 @@
 <tbody>
 <tr>
 	<td>IFRAME</td>
-	<td>//div[contains(@class,'dialog-iframe-bd')]/iframe[contains(@src,'selectDDMStructure')] | //div[contains(@class,'dialog-iframe-bd')]/iframe[contains(@src,'selectStructure')]</td>
+	<td>//div[contains(@class,'dialog-iframe-bd')]/iframe[contains(@src,'selectDDMStructure')] | //div[contains(@class,'dialog-iframe-bd')]/iframe[contains(@src,'selectStructure')] | //iframe[contains(@id,'selectStructure')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
This is a part of [an ongoing epic](https://issues.liferay.com/browse/LPS-129246) to replace legacy AUI-based modals with Clay/React-based `openSelectionModal`. We have previously migrated DDM modals, in #407, but we were not aware of `openDDMPortlet` utilily. This PR is a 2nd part of the task that migrates `openDDMPortlet` related to `structure`, similar to what is being done with `template` in #454.

I have had to migrate `openWindow` to `openModal` in order to maintain the behaviour of opening modal on top of modal, instead of one inside the other.

# 🧪 Testing
1. Run `ant setup-profile-dxp` before `ant all` to gain access to Kaleo Forms Admin
2. Content & Data > Kaleo Forms Admin
3. Create a new Process
4. On the Fields step click on `Add Fields Step` & click on `Parent Field Set` under `Details`