### PR TITLE
LPS-133684 Page is not automatically refreshed when a Field Set is created/edited during the Kaleo Form creation experience

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
@@ -192,23 +192,43 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 		['aui-base']
 	);
 
-	Liferay.provide(
-		window,
-		'<portlet:namespace />editStructure',
-		(title, uri) => {
-			var A = AUI();
+	<portlet:namespace />editStructure = (title, uri) => {
+		let closeRedirectURL;
+		let redirectOnClose = false;
 
-			var WIN = A.config.win;
+		Liferay.Util.openModal({
+			onClose: () => {
+				if (redirectOnClose) {
+					Liferay.Util.navigate(closeRedirectURL);
+				}
+			},
+			onOpen: ({iframeWindow}) => {
+				const closeRedirectElement = iframeWindow.document.getElementById(
+					'_<%= DDMPortletKeys.DYNAMIC_DATA_MAPPING %>_closeRedirect'
+				);
 
-			Liferay.Util.openModal({
-				id: A.guid(),
-				refreshWindow: WIN,
-				title: title,
-				url: uri,
-			});
-		},
-		['liferay-util']
-	);
+				if (closeRedirectElement) {
+					closeRedirectURL = closeRedirectElement.value;
+				}
+
+				const saveButton = iframeWindow.document.querySelector(
+					'.btn-primary'
+				);
+
+				if (saveButton) {
+					const onClick = () => {
+						redirectOnClose = true;
+
+						saveButton.removeEventListener('click', onClick);
+					};
+
+					saveButton.addEventListener('click', onClick);
+				}
+			},
+			title: title,
+			url: uri,
+		});
+	};
 </aui:script>
 
 <aui:script use="liferay-kaleo-forms-components">


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-133683

See description and test case in the JIRA ticket.

The bug was caused by https://github.com/liferay-workflow/liferay-portal/pull/388/commits/d918bc8841950a2e26fda23b00d6cefd835cd3ac, a commit that is a part of our modal migration effort. This is a reincarnation of an old issue, that we had back in https://github.com/liferay-frontend/liferay-portal/pull/31. The root cause is the fact that we are modifying on-close modal behavior, with modification happening after iframe form submit. Support for this for legacy modals is baked [way down on portlet render level](https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/portal/render_portlet.jsp#L1029-L1070). New utility cannot use this and does not support the `refreshWindow` prop. Back in https://github.com/liferay-frontend/liferay-portal/pull/31 we reverted the solution and said we will revisit it later. Well, we are revisiting it now! :slightly_smiling_face: 

Notes:
- To get to the close redirect url, I used the fact that it is stored in `closeRedirect` hidden field of the iframe form. This could be refactored to be served by the module backend, but that's probably outside the scope of this PR.
- I tried to enable redirection on `submit`, but that does not work, because of SPA in iframe. Instead, `click` event on the button does the job.
- We are replacing AUI with vanilla JS in all related code. As a consequence, we can remove `Liferay.provide`.
- Both field set modal and it's child, 'Parent Field Set' modal, have the same size and l&f, as they are opened by the same util. You can see this in the gif below.

/cc @kresimir-coko @julien

After PR:
![after](https://user-images.githubusercontent.com/5435511/121211226-9c607880-c87c-11eb-8d23-22418d22af2d.gif)
