### PR TITLE
LPS-135088 Calendar Widget does not fully fit the column width when configured for "Display Scheduler Only"

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -897,6 +897,12 @@
 			max-width: 60%;
 			width: 60%;
 
+			&.col-md-12 {
+				flex-basis: 100%;
+				max-width: 100%;
+				width: 100%;
+			}
+
 			.scheduler-base-content .scheduler-base-hd {
 				.scheduler-base-controls {
 					width: 100%;
@@ -960,6 +966,12 @@
 			flex: 0 0 65%;
 			max-width: 65%;
 			width: 65%;
+
+			&.col-md-12 {
+				flex-basis: 100%;
+				max-width: 100%;
+				width: 100%;
+			}
 
 			.scheduler-base-content .scheduler-base-hd {
 				.scheduler-base-controls {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135088

h3. Steps to Reproduce:

1. Create a new blank content page
2. Add a grid to the page
3. Adjust the grid down to 2 modules instead of 3 modules
4. Add a paragraph section to the right-hand column
5. Add the calendar widget to the left-hand column
6. Edit the Calendar Configuration to Display Scheduler Events only (uncheck Display User events)
7. Publish
8. Switch back to viewing the page (instead of editing)

**Expected Behavior:**
The Calendar Widget should fill the column

**Observed Behavior:**
The Calendar Widget only fills 60% of the column