### PR TITLE
LPS-155594 Change script tag to aui:script

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/definition/edit_definition.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/definition/edit_definition.jsp
@@ -205,7 +205,7 @@ else {
 	</aui:button-row>
 </aui:form>
 
-<script type="text/javascript">
+<aui:script>
 	AUI().ready((A) => {
 		Liferay.Report.initialize({
 			namespace: '<portlet:namespace />',
@@ -240,4 +240,4 @@ else {
 			);
 		}
 	}
-</script>
+</aui:script>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155594

The issue here was that a "Cannot read property 'initialize' of undefined" error was being thrown when editing a report definition.
I was able to fix this error by changing the script tag to an aui:script tag.
