### PR TITLE
LPS-159054 - Getting the URL from the previous page

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -24,9 +24,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 String backURL = ParamUtil.getString(request, "backURL", redirect);
 
 if (Validator.isNull(backURL)) {
-	PortletURL renderURL = renderResponse.createRenderURL();
-
-	backURL = renderURL.toString();
+	backURL = request.getHeader("referer");
 }
 
 String languageId = LanguageUtil.getLanguageId(request);


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-159054

Hi! This PR, correct the problem of the "Back" button, where when activated it redirected the user to the Worflows Tasks page.
I just put the check to get the previous page. Doubts can call, thank you!