### PR TITLE
LPS-141479 When searching for a Workflow, the search returns past versions of Workflow's title

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/display/context/KaleoDesignerDisplayContext.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/display/context/KaleoDesignerDisplayContext.java
@@ -60,6 +60,7 @@ import com.liferay.portal.workflow.kaleo.designer.web.internal.portlet.display.c
 import com.liferay.portal.workflow.kaleo.designer.web.internal.search.KaleoDefinitionVersionSearch;
 import com.liferay.portal.workflow.kaleo.designer.web.internal.util.filter.KaleoDefinitionVersionActivePredicate;
 import com.liferay.portal.workflow.kaleo.designer.web.internal.util.filter.KaleoDefinitionVersionScopePredicate;
+import com.liferay.portal.workflow.kaleo.designer.web.internal.util.filter.KaleoDefinitionVersionVersionPredicate;
 import com.liferay.portal.workflow.kaleo.designer.web.internal.util.filter.KaleoDefinitionVersionViewPermissionPredicate;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
@@ -771,6 +772,10 @@ public class KaleoDesignerDisplayContext {
 			kaleoDefinitionVersions,
 			new KaleoDefinitionVersionScopePredicate(
 				WorkflowDefinitionConstants.SCOPE_ALL));
+
+		kaleoDefinitionVersions = ListUtil.filter(
+			kaleoDefinitionVersions,
+			new KaleoDefinitionVersionVersionPredicate());
 
 		kaleoDefinitionVersions = ListUtil.filter(
 			kaleoDefinitionVersions,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/util/filter/KaleoDefinitionVersionVersionPredicate.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/util/filter/KaleoDefinitionVersionVersionPredicate.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.workflow.kaleo.designer.web.internal.util.filter;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+
+import java.util.function.Predicate;
+
+/**
+ * @author Michael Cavalcanti
+ */
+public class KaleoDefinitionVersionVersionPredicate
+	implements Predicate<KaleoDefinitionVersion> {
+
+	@Override
+	public boolean test(KaleoDefinitionVersion kaleoDefinitionVersion) {
+		try {
+			KaleoDefinition kaleoDefinition =
+				kaleoDefinitionVersion.getKaleoDefinition();
+
+			if (GetterUtil.getFloat(kaleoDefinitionVersion.getVersion()) ==
+					kaleoDefinition.getVersion()) {
+
+				return true;
+			}
+
+			return false;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		KaleoDefinitionVersionVersionPredicate.class);
+
+}


### PR DESCRIPTION
LPS: [LPS-141479](https://issues.liferay.com/browse/LPS-141479).
I created a new filter that checks if the found version is the most current version, that is, I check if the version of the found version is equal to the version that is stored in the definition, because the definition always stores the most updated version.