### PR TITLE
LPS-144813 When using a workflow with parallel task, the join node is displayed as current node and past node

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
+++ b/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
@@ -33,10 +33,11 @@ const eventObserver = new EventObserver();
 
 export default function WorkflowInstanceTracker({workflowInstanceId}) {
 	const [currentNodes, setCurrentNodes] = useState([]);
+	const [definitionElements, setDefinitionElements] = useState({});
+	const [filteredCurrentNodes, setFilteredCurrentNodes] = useState([]);
 	const [nodes, setNodes] = useState([]);
 	const [transitions, setTransitions] = useState([]);
 	const [visitedNodes, setVisitedNodes] = useState([]);
-	const [definitionElements, setDefinitionElements] = useState({});
 
 	const languageId = themeDisplay.getLanguageId().replace('_', '-');
 
@@ -62,12 +63,12 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 					}
 				)
 					.then((response) => response.json())
-					.then((data) =>
+					.then((data) => {
 						setDefinitionElements({
 							nodes: data.nodes,
 							transitions: data.transitions,
-						})
-					);
+						});
+					});
 			});
 
 		fetch(
@@ -97,7 +98,11 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 					return {
 						data: {
 							current: isCurrent(currentNodes, node),
-							done: isVisited(visitedNodes, node),
+							done: isVisited(
+								visitedNodes,
+								transitionElements,
+								node
+							),
 							initial: node.type === 'INITIAL_STATE',
 							label: node.label,
 							notifyVisibilityChange: (visible) => () => {
@@ -133,6 +138,18 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [definitionElements, visitedNodes]);
 
+	useEffect(() => {
+		const filteredCurrentNodes = [];
+
+		nodes.map((node) => {
+			if (node.data.current) {
+				filteredCurrentNodes.push(node.id);
+			}
+		});
+
+		setFilteredCurrentNodes(filteredCurrentNodes);
+	}, [nodes]);
+
 	const elements = nodes.concat(transitions);
 
 	const layoutedElements = getLayoutedElements(elements);
@@ -159,7 +176,7 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 
 					<Controls showInteractive={false} />
 
-					<CurrentNodes nodesNames={currentNodes} />
+					<CurrentNodes nodesNames={filteredCurrentNodes} />
 				</ReactFlowProvider>
 			)}
 		</div>

--- a/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/util/util.js
+++ b/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/util/util.js
@@ -181,11 +181,23 @@ const getNodeType = (type) => {
 };
 
 const isCurrent = (currentNodes = [], node) => {
-	return currentNodes.includes(node.name);
+	return node.type === 'TASK' && currentNodes.includes(node.name);
 };
 
-const isVisited = (visitedNodes = [], node) => {
-	return visitedNodes.includes(node.name);
+const isVisited = (visitedNodes = [], transitionElements = [], node) => {
+	if (node.type === 'JOIN') {
+		const transitionsToJoin = transitionElements.filter(
+			(element) => element.targetNodeName === node.name
+		).length;
+		const visitedNodesJoin = visitedNodes.filter(
+			(element) => element === node.name
+		).length;
+
+		return transitionsToJoin === visitedNodesJoin;
+	}
+	else {
+		return visitedNodes.includes(node.name);
+	}
 };
 
 const nodeTypes = {


### PR DESCRIPTION
LPS: [LPS-144813](https://issues.liferay.com/browse/LPS-144813)

From what i could understand about the workflow business rule, the tasks are the only steps where the action of third parties is expected, consequently it is the only step in which the current nodes of the workflow will be, so I added a filter so that the current nodes only accept task values.
I also added a filter for the visited nodes, the join being the only one that has a different behavior, I added a filter to meet your specific conditions.

Example:
![image](https://user-images.githubusercontent.com/99838988/194385669-4a82737b-ed49-4e8b-b42b-3cb41da2084f.png)
