### PR TITLE
[TS] LPS-166206 Encode special characters before decoding it to successfully save notification template

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/DiagramBuilder.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/DiagramBuilder.js
@@ -357,7 +357,9 @@ export default function DiagramBuilder() {
 							totalModifications: version,
 						});
 
-						deserializeUtil.updateXMLDefinition(content);
+						deserializeUtil.updateXMLDefinition(
+							encodeURIComponent(content)
+						);
 
 						const metadata = deserializeUtil.getMetadata();
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
@@ -150,11 +150,21 @@ const NotificationsInfo = ({
 
 	const [items, setItems] = useState(notificationTypesOptions);
 
-	const [recipientType, setRecipientType] = useState(
-		getRecipientType(
+	let recipientTypeHolder;
+
+	if (
+		selectedItem.data.notifications?.recipients?.[notificationIndex]
+			.length !== 0
+	) {
+		recipientTypeHolder = getRecipientType(
 			selectedItem.data.notifications?.recipients?.[notificationIndex]
-		) || 'assetCreator'
-	);
+		);
+	}
+	else {
+		recipientTypeHolder = 'assetCreator';
+	}
+
+	const [recipientType, setRecipientType] = useState(recipientTypeHolder);
 
 	const RecipientTypeComponent = recipientTypeComponents[recipientType];
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/utils.js
@@ -15,7 +15,7 @@ const getRecipientType = (assignments) => {
 		? 'assetCreator'
 		: assignments?.assignmentType[0] === 'roleId'
 		? 'role'
-		: assignments?.assignmentType[0];
+		: 'assetCreator';
 };
 
 export {getRecipientType};


### PR DESCRIPTION
Hi Team,

**Issue**
In the workflow definition, when creating a new notification, the (freemarker) template is not saved successfully when it contains a "%" character. Also, when the notification is saved (with or without the special character) and we want to visit that notification again, the page goes blank with an error that is caused by an undefined value [here](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js#L153-L156).
`utils.js:13 Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at getRecipientType (utils.js:13:9)
    at NotificationsInfo (NotificationsInfo.js:154:3)`

LPS: https://issues.liferay.com/browse/LPS-166206

**Fix**
Encoding the content before decoding it.
Null check for Recipient Type

Could you please review it?
Thank you.