### PR TITLE
[TS] LPS-162388 Cannot mark notification from workflow as read if user is not a reviewer or similar

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
@@ -100,39 +100,6 @@ public class WorkflowTaskUserNotificationHandler
 	}
 
 	@Override
-	public boolean isApplicable(
-		UserNotificationEvent userNotificationEvent,
-		ServiceContext serviceContext) {
-
-		try {
-			JSONObject jsonObject = _jsonFactory.createJSONObject(
-				userNotificationEvent.getPayload());
-
-			long ctCollectionId = jsonObject.getLong(
-				WorkflowConstants.CONTEXT_CT_COLLECTION_ID);
-
-			try (SafeCloseable safeCloseable =
-					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-						ctCollectionId)) {
-
-				for (User user :
-						WorkflowTaskManagerUtil.getNotifiableUsers(
-							jsonObject.getLong("workflowTaskId"))) {
-
-					if (user.getUserId() == serviceContext.getUserId()) {
-						return true;
-					}
-				}
-			}
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
-
-		return false;
-	}
-
-	@Override
 	protected String getBody(
 			UserNotificationEvent userNotificationEvent,
 			ServiceContext serviceContext)
@@ -177,6 +144,10 @@ public class WorkflowTaskUserNotificationHandler
 			UserNotificationEvent userNotificationEvent,
 			ServiceContext serviceContext)
 		throws Exception {
+
+		if (!_shouldHaveLink(userNotificationEvent, serviceContext)) {
+			return StringPool.BLANK;
+		}
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			userNotificationEvent.getPayload());
@@ -272,6 +243,38 @@ public class WorkflowTaskUserNotificationHandler
 
 		return _workflowTaskPermission.contains(
 			themeDisplay.getPermissionChecker(), workflowTask, groupId);
+	}
+
+	private boolean _shouldHaveLink(
+		UserNotificationEvent userNotificationEvent,
+		ServiceContext serviceContext) {
+
+		try {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				userNotificationEvent.getPayload());
+
+			long ctCollectionId = jsonObject.getLong(
+				WorkflowConstants.CONTEXT_CT_COLLECTION_ID);
+
+			try (SafeCloseable safeCloseable =
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollectionId)) {
+
+				for (User user :
+						WorkflowTaskManagerUtil.getNotifiableUsers(
+							jsonObject.getLong("workflowTaskId"))) {
+
+					if (user.getUserId() == serviceContext.getUserId()) {
+						return true;
+					}
+				}
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return false;
 	}
 
 	private static final String _BODY_TEMPLATE_DEFAULT =

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -150,43 +150,6 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testIsApplicable() {
-		User user1 = Mockito.mock(User.class);
-
-		Mockito.when(
-			user1.getUserId()
-		).thenReturn(
-			_USER_ID
-		);
-
-		_allowedUsers.add(user1);
-
-		User user2 = Mockito.mock(User.class);
-
-		Mockito.when(
-			user2.getUserId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
-		_allowedUsers.add(user2);
-
-		Assert.assertTrue(
-			_workflowTaskUserNotificationHandler.isApplicable(
-				mockUserNotificationEvent(
-					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-
-		_allowedUsers.remove(user1);
-
-		Assert.assertFalse(
-			_workflowTaskUserNotificationHandler.isApplicable(
-				mockUserNotificationEvent(
-					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-	}
-
-	@Test
 	public void testNullWorkflowTaskIdShouldReturnBlankLink() throws Exception {
 		Assert.assertEquals(
 			StringPool.BLANK,

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -167,15 +167,6 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testValidWorkflowTaskIdShouldReturnBody() throws Exception {
-		Assert.assertEquals(
-			_NOTIFICATION_MESSAGE,
-			_workflowTaskUserNotificationHandler.getBody(
-				mockUserNotificationEvent(null, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-	}
-
-	@Test
 	public void testValidWorkflowTaskIdAllowedUserShouldReturnLink()
 		throws Exception {
 
@@ -206,6 +197,15 @@ public class WorkflowTaskUserNotificationHandlerTest {
 			_workflowTaskUserNotificationHandler.getLink(
 				mockUserNotificationEvent(
 					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
+				_serviceContext));
+	}
+
+	@Test
+	public void testValidWorkflowTaskIdShouldReturnBody() throws Exception {
+		Assert.assertEquals(
+			_NOTIFICATION_MESSAGE,
+			_workflowTaskUserNotificationHandler.getBody(
+				mockUserNotificationEvent(null, null, _VALID_WORKFLOW_TASK_ID),
 				_serviceContext));
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -213,9 +213,33 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testValidWorkflowTaskIdShouldReturnLink() throws Exception {
+	public void testValidWorkflowTaskIdAllowedUserShouldReturnLink()
+		throws Exception {
+
+		User user1 = Mockito.mock(User.class);
+
+		Mockito.when(
+			user1.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		_allowedUsers.add(user1);
+
 		Assert.assertEquals(
 			_VALID_LINK,
+			_workflowTaskUserNotificationHandler.getLink(
+				mockUserNotificationEvent(
+					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
+				_serviceContext));
+	}
+
+	@Test
+	public void testValidWorkflowTaskIdNotAllowedUserShouldReturnBlankLink()
+		throws Exception {
+
+		Assert.assertEquals(
+			StringPool.BLANK,
 			_workflowTaskUserNotificationHandler.getLink(
 				mockUserNotificationEvent(
 					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),


### PR DESCRIPTION
Hi @liferay-workflow team,

This PR is a proposed solution for the issue [LPS-162388](https://issues.liferay.com/browse/LPS-162388) about not being able to mark certain notifications as read (regression of [LPS-146463](https://issues.liferay.com/browse/LPS-146463)).

The problematic situation the PR solves is described in [LPS-162388](https://issues.liferay.com/browse/LPS-162388). In short, an asset under a workflow has been submitted and a user is notified but they don't have the permission to assign it to themselves or anything else. Although there's a notification badge says there's an unread message, the notification itself shows as read, so the notification badge doesn't go away.

Description of the solution:

- The problem was in the use of the method `isApplicable`. This method is related to the attribute `applicable` in `UserNotificationFeedEntry` and was introduced in [LPS-77880](https://issues.liferay.com/browse/LPS-77880) to handle ephemeral notifications for withdrawn submissions. The idea is that non-applicable notifications are totally non-interactive: they're marked as read, have no link and have no actions. (The name is not the best one, unfortunately.)

- For the use case in [LPS-162388](https://issues.liferay.com/browse/LPS-162388) we don't want to be so drastic: the notification should be marked as unread and should have actions associated to it to mark it as read and deleted. 

- The solution proposed removes the overwriting of `isApplicable` in `WorkflowTaskUserNotificationHandler` to leave as default (`true`) but will use the same underlying logic to obtain the link: if the user is not allowed they should get no link to go further. 

- The rest of the relevant code doesn't need to change: 
  - `BaseUserNotificationHandler` or `NotificationsManagementToolbarDisplayContext` will work as they are. 
  - The JSP `user_notification_entry.jspf` will also work as is: since the notfication is applicable now it will try check if the link is empty and if so, will set it to the current URL (so that clicking on it just marks the notification as read). It will also print the body and the action 3-menu (to mark as read/unread and delete).

- Since `isApplicable` has been moved in the local method `_shouldHaveLink`, the associated test `testIsApplicable` in `WorkflowTaskUserNotificationHandlerTest` is removed and `testValidWorkflowTaskIdShouldReturnLink` is split in two tests depending on whether the user is allowed or not.

Note:

- This is the simplest solution I could come up with. Another approach I considered involved adding another attribute in `UserNotificationFeedEntry` in the style of `applicable` and leaving the implementation of `isApplicable` as is. The problem I see with it is that we're changing the semantics of `applicable` which is supposed to be used for totally non-interactive notifications. We'd also need several other changes in the code making that approach more complicated.

Please let me know if you have any questions.

Thanks!