### PR TITLE
[TS] LPS-162388 Cannot mark notification from workflow as read if user is not a reviewer or similar

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -150,43 +150,6 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testIsApplicable() {
-		User user1 = Mockito.mock(User.class);
-
-		Mockito.when(
-			user1.getUserId()
-		).thenReturn(
-			_USER_ID
-		);
-
-		_allowedUsers.add(user1);
-
-		User user2 = Mockito.mock(User.class);
-
-		Mockito.when(
-			user2.getUserId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
-		_allowedUsers.add(user2);
-
-		Assert.assertTrue(
-			_workflowTaskUserNotificationHandler.isApplicable(
-				mockUserNotificationEvent(
-					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-
-		_allowedUsers.remove(user1);
-
-		Assert.assertFalse(
-			_workflowTaskUserNotificationHandler.isApplicable(
-				mockUserNotificationEvent(
-					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-	}
-
-	@Test
 	public void testNullWorkflowTaskIdShouldReturnBlankLink() throws Exception {
 		Assert.assertEquals(
 			StringPool.BLANK,

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -167,15 +167,6 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testValidWorkflowTaskIdShouldReturnBody() throws Exception {
-		Assert.assertEquals(
-			_NOTIFICATION_MESSAGE,
-			_workflowTaskUserNotificationHandler.getBody(
-				mockUserNotificationEvent(null, null, _VALID_WORKFLOW_TASK_ID),
-				_serviceContext));
-	}
-
-	@Test
 	public void testValidWorkflowTaskIdAllowedUserShouldReturnLink()
 		throws Exception {
 
@@ -206,6 +197,15 @@ public class WorkflowTaskUserNotificationHandlerTest {
 			_workflowTaskUserNotificationHandler.getLink(
 				mockUserNotificationEvent(
 					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
+				_serviceContext));
+	}
+
+	@Test
+	public void testValidWorkflowTaskIdShouldReturnBody() throws Exception {
+		Assert.assertEquals(
+			_NOTIFICATION_MESSAGE,
+			_workflowTaskUserNotificationHandler.getBody(
+				mockUserNotificationEvent(null, null, _VALID_WORKFLOW_TASK_ID),
 				_serviceContext));
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -213,9 +213,33 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	@Test
-	public void testValidWorkflowTaskIdShouldReturnLink() throws Exception {
+	public void testValidWorkflowTaskIdAllowedUserShouldReturnLink()
+		throws Exception {
+
+		User user1 = Mockito.mock(User.class);
+
+		Mockito.when(
+			user1.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		_allowedUsers.add(user1);
+
 		Assert.assertEquals(
 			_VALID_LINK,
+			_workflowTaskUserNotificationHandler.getLink(
+				mockUserNotificationEvent(
+					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),
+				_serviceContext));
+	}
+
+	@Test
+	public void testValidWorkflowTaskIdNotAllowedUserShouldReturnBlankLink()
+		throws Exception {
+
+		Assert.assertEquals(
+			StringPool.BLANK,
 			_workflowTaskUserNotificationHandler.getLink(
 				mockUserNotificationEvent(
 					_VALID_ENTRY_CLASS_NAME, null, _VALID_WORKFLOW_TASK_ID),


### PR DESCRIPTION
Resend of https://github.com/liferay-workflow/liferay-portal/pull/852:
- Change `_shouldHaveLink` to `_isNotifiable` (see https://github.com/liferay-workflow/liferay-portal/pull/852#pullrequestreview-1201585183)