### PR TITLE
[TS] LPS-172025 Document Preview in Workflow shows metadata inconsistently

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
@@ -685,6 +685,24 @@ public class WorkflowTaskDisplayContext {
 		return showEditURL;
 	}
 
+	public boolean isShowExtraInfo() {
+		if (_showExtraInfo != null) {
+			return _showExtraInfo;
+		}
+
+		if (Objects.equals(
+				ParamUtil.getString(_liferayPortletRequest, "type"),
+				"document")) {
+
+			_showExtraInfo = true;
+		}
+		else {
+			_showExtraInfo = false;
+		}
+
+		return _showExtraInfo;
+	}
+
 	private String _getActorName(WorkflowLog workflowLog) {
 		if (workflowLog.getRoleId() != 0) {
 			Role role = _getRole(workflowLog.getRoleId());
@@ -1035,6 +1053,7 @@ public class WorkflowTaskDisplayContext {
 	private String _orderByType;
 	private String _portletResource;
 	private final Map<Long, Role> _roles = new HashMap<>();
+	private Boolean _showExtraInfo;
 	private final Map<Long, User> _users = new HashMap<>();
 	private WorkflowModelSearchResult<WorkflowTask> _workflowModelSearchResult;
 	private final WorkflowTaskRequestHelper _workflowTaskRequestHelper;

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -65,7 +65,7 @@ renderResponse.setTitle(assetRenderer.getTitle(workflowTaskDisplayContext.getTas
 						assetEntry="<%= assetEntry %>"
 						assetRenderer="<%= assetRenderer %>"
 						assetRendererFactory="<%= assetRendererFactory %>"
-						showExtraInfo="<%= true %>"
+						showExtraInfo="<%= workflowTaskDisplayContext.isShowExtraInfo() %>"
 					/>
 				</c:if>
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -65,6 +65,7 @@ renderResponse.setTitle(assetRenderer.getTitle(workflowTaskDisplayContext.getTas
 						assetEntry="<%= assetEntry %>"
 						assetRenderer="<%= assetRenderer %>"
 						assetRendererFactory="<%= assetRendererFactory %>"
+						showExtraInfo="<%= true %>"
 					/>
 				</c:if>
 

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowInstanceViewDisplayContext.java
@@ -77,6 +77,8 @@ public class WorkflowInstanceViewDisplayContext
 		throws PortalException {
 
 		super(liferayPortletRequest, liferayPortletResponse);
+
+		_liferayPortletRequest = liferayPortletRequest;
 	}
 
 	public String getAssetIconCssClass(WorkflowInstance workflowInstance) {
@@ -409,6 +411,24 @@ public class WorkflowInstanceViewDisplayContext
 		return false;
 	}
 
+	public boolean isShowExtraInfo() {
+		if (_showExtraInfo != null) {
+			return _showExtraInfo;
+		}
+
+		if (Objects.equals(
+				ParamUtil.getString(_liferayPortletRequest, "type"),
+				"document")) {
+
+			_showExtraInfo = true;
+		}
+		else {
+			_showExtraInfo = false;
+		}
+
+		return _showExtraInfo;
+	}
+
 	protected String getAssetType(String keywords) {
 		for (WorkflowHandler<?> workflowHandler :
 				getSearchableAssetsWorkflowHandlers()) {
@@ -536,9 +556,11 @@ public class WorkflowInstanceViewDisplayContext
 
 	private String _displayStyle;
 	private String _keywords;
+	private final LiferayPortletRequest _liferayPortletRequest;
 	private String _navigation;
 	private String _orderByCol;
 	private String _orderByType;
 	private WorkflowInstanceSearch _searchContainer;
+	private Boolean _showExtraInfo;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view_content.jsp
@@ -46,6 +46,7 @@ renderResponse.setTitle(assetRenderer.getTitle(locale));
 				assetEntry="<%= assetEntry %>"
 				assetRenderer="<%= assetRenderer %>"
 				assetRendererFactory="<%= assetRendererFactory %>"
+				showExtraInfo="<%= workflowInstanceViewDisplayContext.isShowExtraInfo() %>"
 			/>
 
 			<%


### PR DESCRIPTION
Hi @liferay-workflow team,

Documents under a workflow are shown extra information about only when there's no preview available (see JSP https://github.com/liferay-workflow/liferay-portal/blob/master/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp#L34). 

Since the availability of this information shouldn't depend on this, we can align all cases by using the boolean `showExtraInfo` that will make sure that information is always shown if `true`. 

Please let me know if you have any questions. 

Thanks!