### PR TITLE
[TS] LPS-174388 Clear user email when switching to Asset Creator

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
@@ -324,6 +324,15 @@ const NotificationsInfo = ({
 
 				if (recipientType === 'assetCreator') {
 					recipientDetails = {assignmentType: ['user']};
+					if (
+						selectedItem.data.notifications.recipients[
+							notificationIndex
+						]
+					) {
+						delete selectedItem.data.notifications?.recipients?.[
+							notificationIndex
+						].emailAddress;
+					}
 				}
 				else if (recipientType === 'taskAssignees') {
 					recipientDetails = {assignmentType: ['taskAssignees']};


### PR DESCRIPTION
Hi Team,

Can you help review this PR?

Notes from @noornajj:

> https://issues.liferay.com/browse/LPS-174388
> 
> The issue here is Recipient Type doesn't get updated when switching from "User" to "Asset Creator"
> The reason is that "Asset Creator" is saved as assignmentType = 'user'; same as "User". When the recipient type is changed from "User" to "Asset Creator" the "emailAddress" property doesn't get cleared from the assignments object. Therefore, assignmentType = 'user' is assumed to be "User" instead of "Asset Creator"
> 
> To fix the issue, I had the user data cleared when the recipient type is "Asset Creator".

Please let us know if you have any questions.
Thanks!