### PR TITLE
LPS-174984

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/display_settings.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/display_settings.jspf
@@ -39,6 +39,11 @@
 			<aui:option label="3" value="<%= 3 %>" />
 			<aui:option label="4" value="<%= 4 %>" />
 			<aui:option label="5" value="<%= 5 %>" />
+			<aui:option label="7" value="<%= 7 %>" />
+			<aui:option label="10" value="<%= 10 %>" />
+			<aui:option label="14" value="<%= 14 %>" />
+			<aui:option label="21" value="<%= 21 %>" />
+			<aui:option label="31" value="<%= 31 %>" />
 		</aui:select>
 
 		<aui:select label="maximum-events-to-display" name="eventsPerPage">

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/scheduler.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/scheduler.jsp
@@ -90,7 +90,7 @@ String viewCalendarBookingURL = ParamUtil.getString(request, "viewCalendarBookin
 
 	<c:if test="<%= !hideAgendaView %>">
 		window.<portlet:namespace />agendaView = new Liferay.SchedulerAgendaView({
-			daysCount: 31,
+			daysCount: <%= maxDaysDisplayed %>,
 			height: 700,
 			isoTime: <%= useIsoTimeFormat %>,
 			readOnly: <%= readOnly %>,


### PR DESCRIPTION
Hi Team,

could you pease check my fix.

**Steps to Reproduce:**

1) Start a Liferay bundle
2) Add Calendar portlet to a page.
3) Go to Configurations of calendar portlet.
4) Go to display settings and do the following settings.
i) Enable only the Agenda view
ii) Select “Maximum Days to Display” as 0
iii) Select “Maximum Events to Display” 4 (default value)
5) Save the settings and publish the page
6) Go to Calendar and click on “Add Event”, give the following details:
i) Title as “My Event”
ii) start date as “03rd Feb 2023”
iii) End date as “07th Feb 2023" check “All day” check box
4 to check with max value as well)
7) Click on Publish.
8) Click on “03rd Feb 2023" to check 03rd Feb events and observe the behaviour. 

**Expected Behaviour:** Only the 03rd Feb 2023 event should be displayed as we have selected maxDaysDisplayed as 0.
**Actual Behaviour:** All 5 days events are displayed. (03rd, 04th, 05th, 06th, 07th) with the same repeating event displayed.
Also, I have checked by changing the Maximum Days to Display value to 1,2,3 & 4 but still, it shows all 5 days events

**Fix**

Using maxDaysDisplayed in the Agende view too.
Additionaly i added more options to the Maximum Days to Display configuration.

Thanks, Roland

https://issues.liferay.com/browse/LPS-174984