### PR TITLE
LPS-176070 Wrap component in a div

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-taglib/src/main/resources/META-INF/resources/workflow_status/page.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-taglib/src/main/resources/META-INF/resources/workflow_status/page.jsp
@@ -16,7 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
-<react:component
-	module="workflow_status/js/WorkflowStatus"
-	props="<%= workflowStatusDisplayContext.getData(request, locale) %>"
-/>
+<div>
+	<react:component
+		module="workflow_status/js/WorkflowStatus"
+		props="<%= workflowStatusDisplayContext.getData(request, locale) %>"
+	/>
+</div>


### PR DESCRIPTION
Hi team!

I'm sending this PR because we plan to start using `liferay-portal-workflow:status` taglib in our components, and we have noticed that the react component is not wrapped in a `div`.

This could cause the taglib removing all sibling markup when being used in other `jsp`'s, so I'm just wrapping the component in a `div`.

Please let me know what you think, thanks! 😄