### PR TITLE
LPS-165336 Change localStorage to new API

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/shared/components/toolbar/UpperToolbar.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/shared/components/toolbar/UpperToolbar.js
@@ -16,6 +16,7 @@ import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayToolbar from '@clayui/toolbar';
 import {TranslationAdminSelector} from 'frontend-js-components-web';
+import {localStorage} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 import {isEdge, isNode} from 'react-flow-renderer';
@@ -220,7 +221,11 @@ export default function UpperToolbar({
 						setDefinitionId(name);
 						setVersion(parseInt(version, 10));
 						if (version === '1') {
-							localStorage.setItem('firstPublished', true);
+							localStorage.setItem(
+								'firstPublished',
+								true,
+								localStorage.TYPES.FUNCTIONAL
+							);
 							redirectToSavedDefinition(name, version);
 						}
 						else {
@@ -255,7 +260,11 @@ export default function UpperToolbar({
 						setDefinitionId(name);
 						setVersion(parseInt(version, 10));
 						if (version === '1') {
-							localStorage.setItem('firstSaved', true);
+							localStorage.setItem(
+								'firstSaved',
+								true,
+								localStorage.TYPES.FUNCTIONAL
+							);
 							redirectToSavedDefinition(name, version);
 						}
 						else {
@@ -321,11 +330,16 @@ export default function UpperToolbar({
 	}, [definitionTitle, elements]);
 
 	useEffect(() => {
-		if (localStorage.getItem('firstSaved')) {
+		if (localStorage.getItem('firstSaved', localStorage.TYPES.FUNCTIONAL)) {
 			setAlert(Liferay.Language.get('workflow-saved'), 'success', true);
 			localStorage.removeItem('firstSaved');
 		}
-		else if (localStorage.getItem('firstPublished')) {
+		else if (
+			localStorage.getItem(
+				'firstPublished',
+				localStorage.TYPES.FUNCTIONAL
+			)
+		) {
 			setAlert(
 				Liferay.Language.get('workflow-published-successfully'),
 				'success',


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-165336

Hi reviewer! :cherry_blossom: 

This is related to the major task to remove all session and local storage from the code and use the new API created by de FI team, making Liferay stay in complience with the use of data of users from cookies.

On this specific task I've tried to remove the `localStorage` completely by doing the logic different, but I couldn't make it since the page refreshes on the first save/publish, losing the informations about the response; `useState` doesn't work because of the refresh and `useMemo` could work, but I don't have the infos of the response to make it get right. Therefore, I've kept the `localStorage` code, only changing it to the new API.

If you have any suggestions about this I would be happy to hear, thanks a lot! :purple_heart: 