### PR TITLE
[TS] LPS-178499

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
@@ -144,9 +144,22 @@ const NotificationsInfo = ({
 		selectedItem.data.notifications?.recipients?.[notificationIndex]
 			?.length !== 0
 	) {
-		recipientTypeHolder = getRecipientType(
-			selectedItem.data.notifications?.recipients?.[notificationIndex]
-		);
+		if (
+			!selectedItem.data.notifications?.recipients?.[
+				notificationIndex
+			]?.[0]
+		) {
+			recipientTypeHolder = getRecipientType(
+				selectedItem.data.notifications?.recipients?.[notificationIndex]
+			);
+		}
+		else {
+			recipientTypeHolder = getRecipientType(
+				selectedItem.data.notifications?.recipients?.[
+					notificationIndex
+				][0]
+			);
+		}
 	}
 	else {
 		recipientTypeHolder = 'assetCreator';
@@ -375,7 +388,8 @@ const NotificationsInfo = ({
 
 		const recipients =
 			selectedItem.data.notifications &&
-			selectedItem.data.notifications.recipients[notificationIndex];
+			(selectedItem.data.notifications.recipients[notificationIndex][0] ||
+				selectedItem.data.notifications.recipients[notificationIndex]);
 
 		if (recipients && recipientType === 'roleType') {
 			for (let i = 0; i < recipients.roleType.length; i++) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/Role.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/Role.js
@@ -39,11 +39,19 @@ const Role = ({notificationIndex}) => {
 				id:
 					selectedItem.data.notifications?.recipients?.[
 						notificationIndex
-					]?.sectionsData?.id || '',
+					]?.[0]?.sectionsData?.id ||
+					selectedItem.data.notifications?.recipients?.[
+						notificationIndex
+					]?.sectionsData?.id ||
+					'',
 				name:
 					selectedItem.data.notifications?.recipients?.[
 						notificationIndex
-					]?.sectionsData?.name || '',
+					]?.[0]?.sectionsData?.name ||
+					selectedItem.data.notifications?.recipients?.[
+						notificationIndex
+					]?.sectionsData?.name ||
+					'',
 			}}
 			inputLabel={Liferay.Language.get('role-id')}
 			selectLabel={Liferay.Language.get('role-name')}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
@@ -30,6 +30,10 @@ const populateNotificationsData = (
 			const recipients = element.data.notifications.recipients;
 
 			recipients.map((recipient, index) => {
+				if (recipient[0] !== undefined) {
+					recipient = recipient[0];
+				}
+
 				if (recipient?.assignmentType?.[0] === 'roleId') {
 					retrieveRoleById(recipient.roleId)
 						.then((response) => response.json())

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
@@ -223,8 +223,7 @@ export function parseNotifications(node) {
 				],
 			});
 		}
-
-		if (item['user']) {
+		else if (item['user']) {
 			if (item['user'].some((item) => item['email-address'])) {
 				const emailAddress = [];
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178499

This issue is caused by [LPS-168745](https://issues.liferay.com/browse/LPS-168745)/[LPS-178041](https://issues.liferay.com/browse/LPS-178041), however reverting doesn't seem like a good solution, since the original intent was to add a feature.

My fix is safe, since it makes no assumptions as to whether or not recipients should be received as an array or an object.  With current functionality, either option may be used (`Array` for not yet rendered recipients, `Object` for previously rendered).

I believe a better solution would be to always have the recipients returned as an object, although the commit message from LPS-168745 "Allow multiple recipients for notifications through XML" and [it's change to make each notification an array of arrays](https://github.com/brianchandotcom/liferay-portal/pull/131616/commits/6f047d450db050a2f8e57fc6b2547ac7526f4dc0?diff=unified&w=1#diff-4e496c2cca5553beeb4b5858c021754d3301fc444f3eaedd4329903119a7c8ccL218-R322) makes me hesitant to make the call.

Please let me know if you have any questions, thanks!