### PR TITLE
[TS] LPS-184764 Set VTIMEZONE when creating a Calendar event, so that the exported TZID will always be interpreted in an objective way by every application that imports it.

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/util/CalendarICalDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/util/CalendarICalDataHandler.java
@@ -60,12 +60,14 @@ import java.time.temporal.TemporalAmount;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TimeZone;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
@@ -628,7 +630,20 @@ public class CalendarICalDataHandler implements CalendarDataHandler {
 		List<CalendarComponent> calendarComponents =
 			iCalCalendar.getComponents();
 
+		Set<String> timeZoneIds = new HashSet<>();
+
 		for (CalendarBooking calendarBooking : calendarBookings) {
+			TimeZone timeZone = calendarBooking.getTimeZone();
+
+			String timeZoneId = timeZone.getID();
+
+			if (timeZoneIds.add(timeZoneId)) {
+				net.fortuna.ical4j.model.TimeZone icalTimeZone =
+					_toICalTimeZone(timeZone);
+
+				calendarComponents.add(icalTimeZone.getVTimeZone());
+			}
+
 			calendarComponents.add(_toICalEvent(calendarBooking));
 		}
 


### PR DESCRIPTION
Ticket: [LPS-184764](https://issues.liferay.com/browse/LPS-184764)