### PR TITLE
LPS-183752 Dropdown button in Metrics page header is misaligned

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderKebab.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderKebab.es.js
@@ -32,7 +32,7 @@ const HeaderKebab = ({kebabItems = []}) => {
 	return (
 		<Portal
 			className="control-menu-nav-item"
-			container={nav?.lastElementChild}
+			container={nav?.firstElementChild}
 			elementId="headerKebab"
 			position="before"
 		>


### PR DESCRIPTION
Hello Reviewer!
Related Issue: https://issues.liferay.com/browse/LPS-183752

To solve the problem, the container was changed to `nav?.firstElementChild`, moving it to the desired location.