### PR TITLE
LPS-186311 Can't edit a repeating event when there an user invited to it

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -1047,6 +1047,12 @@ while (manageableCalendarsIterator.hasNext()) {
 
 	if (allDayCheckbox) {
 		allDayCheckbox.addEventListener('click', (event) => {
+			var endDateContainer = document.getElementById(
+				'<portlet:namespace />endDateContainer'
+			);
+			var startDateContainer = document.getElementById(
+				'<portlet:namespace />startDateContainer'
+			);
 			var endTimeHours;
 			var endTimeMinutes;
 			var startTimeHours;


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-186311

It was not possible to edit the event under the following conditions:
- The event was created and someone was invited to it;
- Repetitions were applied to the event.

Whenever we tried to edit the event or perform a drag and drop, it would enter into a "loading state" with a faded out screen, but it would not go anywhere from there.

I tried testing the bug with and without invitees, with and without repetition, and using the all day checkbox.

To investigate and "resolve" the problem, I tested in an earlier version (7.3.xx) and found out that it was working, so I [checked an old alteration](https://github.com/liferay/liferay-portal/commit/ad8d04f39f0297a3b06f2d24fd12c791b57c4a13) and tried a bunch of things. 

I ended up returning the endDateContainer and startDateContainer variables inside the allDayCheckbox condition code block.

It seems to solve the problem. but I am not really sure why. I imagine that these values had to be used inside of the scope of the condition to work the way they were supposed to work. However, It is just a guess.

