### PR TITLE
[TS] LPP-49342>>LPS-189561 If a calendar event starts at 12:00am, the same event will appear in the previous day's agenda.

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
@@ -713,7 +713,7 @@ AUI.add(
 						date = DateMath.add(
 							date,
 							DateMath.DAY,
-							maxDaysDisplayed
+							maxDaysDisplayed - 1
 						);
 
 						date = DateMath.subtract(date, DateMath.MINUTES, 1);


### PR DESCRIPTION
Hi team,
This PR is for fixing https://liferay.atlassian.net/browse/LPS-189561
The solution is set the maxDaysDisplayed -1. So that after adding, the end date value will be in the same date with the start date, then it will show the events which present in that day.
Please review and leave your comment
Thanks,
Quan
cc @locpham97