### PR TITLE
LPS-187768 Switch iText under AGPL (as dependency of JasperReport) for OpenPDF (an LGPL - licensed fork of iText)

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-jasper/build.gradle
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-jasper/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
 	compileInclude group: "antlr", name: "antlr", version: "2.7.5"
+	compileInclude group: "com.github.librepdf", name: "openpdf", version: "1.3.11"
 	compileInclude group: "com.google.zxing", name: "core", version: "3.2.1"
 	compileInclude group: "com.ibm.icu", name: "icu4j", version: "57.1"
-	compileInclude group: "com.liferay", name: "com.lowagie.itext", version: "2.1.7.js10.LIFERAY-PATCHED-1"
 	compileInclude group: "commons-collections", name: "commons-collections", version: "3.2.2"
 	compileInclude group: "net.sf.jasperreports", name: "jasperreports", version: "6.20.0"
 	compileInclude group: "net.sf.jasperreports", name: "jasperreports-fonts", version: "6.20.0"


### PR DESCRIPTION
Related to: [LPS-187768](https://liferay.atlassian.net/browse/LPS-187768)