### PR TITLE
[TECHNICAL SUPPORT] LPS-190808 Image in Workflow Preview overflows

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
@@ -368,3 +368,13 @@
 .navigation-bar-light {
 	padding-top: 2.5rem;
 }
+
+.container-view {
+	.card {
+		.panel-body {
+			img {
+				max-width: 100%;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hey,
[LPS-190808](https://liferay.atlassian.net/browse/LPS-190808),

The image overflowed in preview and I contained it with a max-width attribute. Please review my changes

Thanks