### PR TITLE
[TS] LPS-171646 - calendar bookings should not be listed as selectable when making collections

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/asset/model/CalendarBookingAssetRendererFactory.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/asset/model/CalendarBookingAssetRendererFactory.java
@@ -62,6 +62,7 @@ public class CalendarBookingAssetRendererFactory
 		setClassName(CalendarBooking.class.getName());
 		setPortletId(CalendarPortletKeys.CALENDAR);
 		setSearchable(true);
+		setSelectable(false);
 	}
 
 	@Override


### PR DESCRIPTION
Hi @liferay-workflow team,

This is to address a client's issue in [LPS-171646](https://liferay.atlassian.net/browse/LPS-171646) which related to them realizing that Calendar Bookings are listed when creating a Collection, but cannot be used with Collection Display fragments. In [PTR-3561](https://liferay.atlassian.net/browse/PTR-3561) it was decided by your team that Calendar Bookings being listed in this was a bug due to not being a part of the info framework. I understood this to mean that we should not be able to make collections at all using a Calendar Booking and therefore added the setSelectable(false) to the asset renderer factory, but please let me know if I'm misunderstanding the intended state of Calendar Bookings. Thanks!