### PR TITLE
[TS] LPS-191809 Kaleo Designer's fetch util doesn't account for custom context

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.js
@@ -46,10 +46,13 @@ function retrieveDefinitionRequest(definitionId, versionNumber) {
 }
 
 function retrieveRoleById(roleId) {
-	return fetch(`${window.location.origin}${userBaseURL}/roles/${roleId}`, {
-		headers,
-		method: 'GET',
-	});
+	return fetch(
+		`${window.location.origin}${contextUrl}${userBaseURL}/roles/${roleId}`,
+		{
+			headers,
+			method: 'GET',
+		}
+	);
 }
 
 function retrieveRoles() {
@@ -73,7 +76,7 @@ function retrieveUsersBy(filterType, keywords) {
 		.slice(0, -8);
 
 	const url = new URL(
-		`${window.location.origin}${userBaseURL}/user-accounts?filter=${filterParameter}`
+		`${window.location.origin}${contextUrl}${userBaseURL}/user-accounts?filter=${filterParameter}`
 	);
 
 	return fetch(url, {


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
Setting a custom root context in Liferay can cause errors in Kaleo Designer because the fetch URLs for retrieving users and roles will have the context missing. 

Proposed Solution
========
Including the context in the fetch URLs.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-191809

Thank you and best regards,
István