### PR TITLE
LPS-189952 Create a ServiceWrapper to always force propagation from site template to site after updateLayoutSetPrototypeLinkEnabled

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutSetLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutSetLocalServiceWrapper.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.service;
+
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.sites.kernel.util.Sites;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author To Trinh
+ */
+@Component(service = ServiceWrapper.class)
+public class LayoutSetLocalServiceWrapper
+	extends com.liferay.portal.kernel.service.LayoutSetLocalServiceWrapper {
+
+	@Override
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean privateLayout,
+			boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException {
+
+		super.updateLayoutSetPrototypeLinkEnabled(
+			groupId, privateLayout, layoutSetPrototypeLinkEnabled,
+			layoutSetPrototypeUuid);
+
+		try {
+			MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
+
+			_sites.mergeLayoutSetPrototypeLayouts(
+				_groupLocalService.getGroup(groupId),
+				_layoutSetLocalService.getLayoutSet(groupId, privateLayout));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Could not force propagation from site template to site",
+					exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutSetLocalServiceWrapper.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference
+	private Sites _sites;
+
+}

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -2394,14 +2394,6 @@ public class SitesImpl implements Sites {
 			layoutSetPrototypeUuid);
 
 		LayoutLocalServiceUtil.updatePriorities(groupId, privateLayout);
-
-		// Force propagation from site template to site. See LPS-48206.
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
-		mergeLayoutSetPrototypeLayouts(
-			GroupLocalServiceUtil.getGroup(groupId),
-			LayoutSetLocalServiceUtil.getLayoutSet(groupId, privateLayout));
 	}
 
 	private String _acquireLock(


### PR DESCRIPTION
Hi team,
Please help review this PR and leave your comments.
Ticket:
https://liferay.atlassian.net/browse/LPS-189952
Root cause:
I found that when accessing the page, the mergeLayoutSetPrototypeLayouts process will be executed and acts as a background task. This is what causes the Home page not to exist when accessing the page for the first time.
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L1565-L1567
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java#L4056-L4062
Solution:
Create a ServiceWrapper to always force propagation from site template to site after updateLayoutSetPrototypeLinkEnabled.

Thanks.
cc @tototrinh 