### PR TITLE
[TS] LPS-194619 LPS-190884

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelector.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelector.java
@@ -74,7 +74,8 @@ public class MultiLanguageKaleoTaskAssignmentSelector
 		if (scriptedAssignmentCacheExpirationTime > 0) {
 			kaleoTaskAssignments =
 				_kaleoTaskScriptedAssignmentCache.getKaleoTaskAssignments(
-					kaleoTaskAssignment.getKaleoTaskAssignmentId());
+					_kaleoTaskScriptedAssignmentCache.getKey(
+						executionContext.getKaleoInstanceToken()));
 		}
 
 		if (kaleoTaskAssignments == null) {
@@ -84,7 +85,8 @@ public class MultiLanguageKaleoTaskAssignmentSelector
 
 			if (scriptedAssignmentCacheExpirationTime > 0) {
 				_kaleoTaskScriptedAssignmentCache.putKaleoTaskAssignments(
-					kaleoTaskAssignment.getKaleoTaskAssignmentId(),
+					_kaleoTaskScriptedAssignmentCache.getKey(
+						executionContext.getKaleoInstanceToken()),
 					kaleoTaskAssignments,
 					scriptedAssignmentCacheExpirationTime * 60);
 			}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelector.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelector.java
@@ -61,6 +61,9 @@ public class MultiLanguageKaleoTaskAssignmentSelector
 
 		Collection<KaleoTaskAssignment> kaleoTaskAssignments = null;
 
+		KaleoInstanceToken kaleoInstanceToken =
+			executionContext.getKaleoInstanceToken();
+
 		WorkflowTaskScriptConfiguration workflowTaskScriptConfiguration =
 			ConfigurationProviderUtil.getConfiguration(
 				WorkflowTaskScriptConfiguration.class,
@@ -75,7 +78,7 @@ public class MultiLanguageKaleoTaskAssignmentSelector
 			kaleoTaskAssignments =
 				_kaleoTaskScriptedAssignmentCache.getKaleoTaskAssignments(
 					_kaleoTaskScriptedAssignmentCache.getKey(
-						executionContext.getKaleoInstanceToken()));
+						kaleoInstanceToken));
 		}
 
 		if (kaleoTaskAssignments == null) {
@@ -86,14 +89,11 @@ public class MultiLanguageKaleoTaskAssignmentSelector
 			if (scriptedAssignmentCacheExpirationTime > 0) {
 				_kaleoTaskScriptedAssignmentCache.putKaleoTaskAssignments(
 					_kaleoTaskScriptedAssignmentCache.getKey(
-						executionContext.getKaleoInstanceToken()),
+						kaleoInstanceToken),
 					kaleoTaskAssignments,
 					scriptedAssignmentCacheExpirationTime * 60);
 			}
 		}
-
-		KaleoInstanceToken kaleoInstanceToken =
-			executionContext.getKaleoInstanceToken();
 
 		_kaleoInstanceLocalService.updateKaleoInstance(
 			kaleoInstanceToken.getKaleoInstanceId(),

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/cache/KaleoTaskScriptedAssignmentCache.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/cache/KaleoTaskScriptedAssignmentCache.java
@@ -7,6 +7,7 @@ package com.liferay.portal.workflow.kaleo.runtime.internal.cache;
 
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignment;
 
 import java.util.ArrayList;
@@ -23,25 +24,27 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = KaleoTaskScriptedAssignmentCache.class)
 public class KaleoTaskScriptedAssignmentCache {
 
-	public Collection<KaleoTaskAssignment> getKaleoTaskAssignments(
-		long kaleoTaskAssignmentId) {
+	public Collection<KaleoTaskAssignment> getKaleoTaskAssignments(String key) {
+		return _portalCache.get(key);
+	}
 
-		return _portalCache.get(kaleoTaskAssignmentId);
+	public String getKey(KaleoInstanceToken kaleoInstanceToken) {
+		return kaleoInstanceToken.getKaleoInstanceTokenId() + "#" +
+			kaleoInstanceToken.getCurrentKaleoNodeId();
 	}
 
 	public void putKaleoTaskAssignments(
-		long kaleoTaskAssignmentId,
-		Collection<KaleoTaskAssignment> kaleoTaskAssignments, int timeToLive) {
+		String key, Collection<KaleoTaskAssignment> kaleoTaskAssignments,
+		int timeToLive) {
 
 		_portalCache.put(
-			kaleoTaskAssignmentId, new ArrayList<>(kaleoTaskAssignments),
-			timeToLive);
+			key, new ArrayList<>(kaleoTaskAssignments), timeToLive);
 	}
 
 	@Activate
 	protected void activate() {
 		_portalCache =
-			(PortalCache<Long, ArrayList<KaleoTaskAssignment>>)
+			(PortalCache<String, ArrayList<KaleoTaskAssignment>>)
 				_multiVMPool.getPortalCache(
 					KaleoTaskScriptedAssignmentCache.class.getName());
 	}
@@ -55,6 +58,6 @@ public class KaleoTaskScriptedAssignmentCache {
 	@Reference
 	private MultiVMPool _multiVMPool;
 
-	private PortalCache<Long, ArrayList<KaleoTaskAssignment>> _portalCache;
+	private PortalCache<String, ArrayList<KaleoTaskAssignment>> _portalCache;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelectorTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/internal/assignment/MultiLanguageKaleoTaskAssignmentSelectorTest.java
@@ -7,7 +7,9 @@ package com.liferay.portal.workflow.kaleo.runtime.internal.assignment;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.settings.SettingsLocator;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -21,6 +23,7 @@ import com.liferay.portal.workflow.kaleo.model.impl.KaleoTaskAssignmentImpl;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 import com.liferay.portal.workflow.kaleo.runtime.assignment.ScriptingAssigneeSelector;
 import com.liferay.portal.workflow.kaleo.runtime.constants.AssigneeConstants;
+import com.liferay.portal.workflow.kaleo.runtime.internal.configuration.WorkflowTaskScriptConfiguration;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 
 import java.util.Collection;
@@ -33,6 +36,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.osgi.framework.BundleContext;
@@ -69,6 +73,22 @@ public class MultiLanguageKaleoTaskAssignmentSelectorTest {
 		MultiLanguageKaleoTaskAssignmentSelector
 			multiLanguageKaleoTaskAssignmentSelector =
 				_getMultiLanguageKaleoTaskAssignmentSelector();
+
+		_workflowTaskScriptConfiguration = Mockito.mock(
+			WorkflowTaskScriptConfiguration.class);
+
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getConfiguration(
+				Mockito.any(Class.class), Mockito.any(SettingsLocator.class))
+		).thenReturn(
+			_workflowTaskScriptConfiguration
+		);
+
+		Mockito.doReturn(
+			0
+		).when(
+			_workflowTaskScriptConfiguration
+		).scriptedAssignmentCacheExpirationTime();
 
 		Collection<KaleoTaskAssignment> kaleoTaskAssignments =
 			multiLanguageKaleoTaskAssignmentSelector.getKaleoTaskAssignments(
@@ -183,8 +203,12 @@ public class MultiLanguageKaleoTaskAssignmentSelectorTest {
 
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
+	private static final MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
 
 	private ServiceRegistration<ScriptingAssigneeSelector> _serviceRegistration;
+	private WorkflowTaskScriptConfiguration _workflowTaskScriptConfiguration;
 
 	private static class TestJavaScriptingAssigneeSelector
 		implements ScriptingAssigneeSelector {


### PR DESCRIPTION
Hi @liferay-workflow team!

This PR fixes 2 issues caused by [LPS-18625](https://liferay.atlassian.net/browse/LPS-186252):
- [LPS-190884](https://liferay.atlassian.net/browse/LPS-190884): The unit test `testUseJavaScriptingKaleoTaskAssignmentSelector` invokes a method (`multiLanguageKaleoTaskAssignmentSelector.getKaleoTaskAssignments`) that requires a configuration but this will timeout after 15 minutes. To fix it, we should mock the configuration itself. We also mock the value of the configuration to return the default value of 0, i.e., no cache.
- [LPS-194619](https://liferay.atlassian.net/browse/LPS-194619): The key used for the `KaleoTaskScriptedAssignmentCache` was the same for different workflow instances of the same workflow definition. To fix it we make a compound key from the `kaleoInstanceTokenId`, which specifies the workflow instance, and the `currentKaleoNodeId` that specifies the node (task in our case). This key is unique for a given task node and a given workflow instance. (See reproducing steps in LPS for more details.)

Please let me know if you have any questions.

Thanks!