### PR TITLE
LPS-194915 Use the user's time zone rather than UTC

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/DefnitionInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/DefnitionInfo.js
@@ -23,13 +23,13 @@ const Details = ({definitionInfo}) => {
 	const titleLastModified = Liferay.Language.get('last-modified');
 	const titleTotalModifications = Liferay.Language.get('total-modifications');
 
-	const dateCreated = moment
-		.utc(definitionInfo.dateCreated)
-		.format(Liferay.Language.get('mmm-dd-yyyy-lt'));
+	const dateCreated = moment(definitionInfo.dateCreated).format(
+		Liferay.Language.get('mmm-dd-yyyy-lt')
+	);
 
-	const dateModified = moment
-		.utc(definitionInfo.dateModified)
-		.format(Liferay.Language.get('mmm-dd-yyyy-lt'));
+	const dateModified = moment(definitionInfo.dateModified).format(
+		Liferay.Language.get('mmm-dd-yyyy-lt')
+	);
 
 	const totalModifications = definitionInfo.totalModifications;
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/hooks/useCustomTimeRange.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/hooks/useCustomTimeRange.es.js
@@ -22,7 +22,7 @@ const updateErrors = (errors, fieldName, message) => ({
 });
 
 const validateDate = (dateEndMoment, dateStartMoment) => {
-	const dateNow = moment.utc();
+	const dateNow = moment();
 	let errors;
 
 	if (!dateEndMoment.isValid() || dateEndMoment.isAfter(dateNow)) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/util/timeRangeUtil.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/util/timeRangeUtil.es.js
@@ -12,11 +12,11 @@ import {
 import moment from '../../../shared/util/moment.es';
 
 const convertQueryDate = (date = '', format = 'L') => {
-	return moment.utc(decodeURIComponent(date), null, 'en').format(format);
+	return moment(decodeURIComponent(date), null, 'en').format(format);
 };
 
 const parseDateMoment = (date, format = 'L') => {
-	return moment.utc(date, format, 'en');
+	return moment(date, format, 'en');
 };
 
 const formatDateTime = (date, format, isEndDate) => {
@@ -69,8 +69,8 @@ const formatTimeRange = (timeRange, isAmPm) => {
 		return null;
 	}
 
-	const dateEndMoment = moment.utc(dateEnd);
-	const dateStartMoment = moment.utc(dateStart);
+	const dateEndMoment = moment(dateEnd);
+	const dateStartMoment = moment(dateStart);
 
 	const {dateEndPattern, dateStartPattern} = getFormatPattern(
 		dateEndMoment,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/util/velocityUnitUtil.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/util/velocityUnitUtil.es.js
@@ -54,8 +54,8 @@ const getVelocityUnits = (timeRange) => {
 		return [];
 	}
 
-	const dateEnd = moment.utc(timeRange.dateEnd);
-	const dateStart = moment.utc(timeRange.dateStart);
+	const dateEnd = moment(timeRange.dateEnd);
+	const dateStart = moment(timeRange.dateStart);
 
 	let daysDiff = dateEnd.diff(dateStart, 'days');
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/InstanceListPageItem.es.js
@@ -168,9 +168,9 @@ function Item({isAdmin, totalCount, ...instance}) {
 			</ClayTable.Cell>
 
 			<ClayTable.Cell>
-				{moment
-					.utc(dateCreated)
-					.format(Liferay.Language.get('mmm-dd-yyyy-lt'))}
+				{moment(dateCreated).format(
+					Liferay.Language.get('mmm-dd-yyyy-lt')
+				)}
 			</ClayTable.Cell>
 
 			<ClayTable.Cell style={{paddingRight: '0rem'}}>
@@ -305,7 +305,7 @@ function DueDateSLAResults({slaResults, slaStatusIconInfo}) {
 				: Liferay.Language.get('mmm-dd-yyyy');
 		}
 
-		return moment.utc(dateOverdue).format(format);
+		return moment(dateOverdue).format(format);
 	};
 
 	const instanceSlaResults = slaResults.slice(0, 2).map((slaResult) => {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
@@ -170,9 +170,9 @@ function Body({
 					{dateCreated && (
 						<Body.SectionAttribute
 							description={Liferay.Language.get('creation-date')}
-							detail={moment
-								.utc(dateCreated)
-								.format(Liferay.Language.get('mmm-dd-yyyy-lt'))}
+							detail={moment(dateCreated).format(
+								Liferay.Language.get('mmm-dd-yyyy-lt')
+							)}
 						/>
 					)}
 
@@ -196,9 +196,9 @@ function Body({
 					{completed && dateCompletion && (
 						<Body.SectionAttribute
 							description={Liferay.Language.get('end-date')}
-							detail={moment
-								.utc(dateCompletion)
-								.format(Liferay.Language.get('mmm-dd-yyyy-lt'))}
+							detail={moment(dateCompletion).format(
+								Liferay.Language.get('mmm-dd-yyyy-lt')
+							)}
 						/>
 					)}
 
@@ -310,11 +310,9 @@ function SLAResultItem({dateOverdue, name, onTime, remainingTime, status}) {
 					remainingTime
 				);
 
-				return `${moment
-					.utc(dateOverdue)
-					.format(
-						Liferay.Language.get('mmm-dd-yyyy-lt')
-					)} (${durationText} ${onTimeText})`;
+				return `${moment(dateOverdue).format(
+					Liferay.Language.get('mmm-dd-yyyy-lt')
+				)} (${durationText} ${onTimeText})`;
 			}
 			default: {
 				if (status === 'STOPPED' && onTime) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/VelocityChart.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/VelocityChart.es.js
@@ -37,7 +37,7 @@ function VelocityChart({timeRange, velocityData = {}, velocityUnit}) {
 	const {intervals, maxValue} = getAxisMeasuresFromData(dataValues);
 
 	const dataChart = histograms.map((data) => {
-		const date = moment.utc(data.key).toDate();
+		const date = moment(data.key).toDate();
 		data.name = formatXAxisDate(date, isAmPm, unitKey, timeRange);
 
 		return data;
@@ -96,7 +96,7 @@ const CustomTooltip = ({active, isAmPm, payload, timeRange, unit, unitKey}) => {
 	const formatTooltipDate = (date, isAmPm, timeRange, unitKey) => {
 		let datePattern = Liferay.Language.get('ddd-mmm-d');
 
-		const dateUTC = moment.utc(date);
+		const dateMoment = moment(date);
 
 		if (unitKey === HOURS) {
 			if (isAmPm) {
@@ -106,7 +106,7 @@ const CustomTooltip = ({active, isAmPm, payload, timeRange, unit, unitKey}) => {
 				datePattern = Liferay.Language.get('mmm-dd-hh-mm');
 			}
 
-			return dateUTC.format(datePattern);
+			return dateMoment.format(datePattern);
 		}
 		else if (unitKey === WEEKS) {
 			return formatWeekDateWithYear(date, timeRange);
@@ -118,7 +118,7 @@ const CustomTooltip = ({active, isAmPm, payload, timeRange, unit, unitKey}) => {
 			return formatYearDate(date, timeRange);
 		}
 
-		return dateUTC.format(datePattern);
+		return dateMoment.format(datePattern);
 	};
 
 	const getDateTitle = (date, isAmPm, timeRange, unitKey) => {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/util/chart.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/util/chart.es.js
@@ -21,9 +21,9 @@ import {
 } from './chartConstants.es';
 
 export function formatMonthDate(date, timeRange) {
-	const currentDate = moment.utc(date);
-	const dateEnd = moment.utc(timeRange.dateEnd);
-	const dateStart = moment.utc(timeRange.dateStart);
+	const currentDate = moment(date);
+	const dateEnd = moment(timeRange.dateEnd);
+	const dateStart = moment(timeRange.dateStart);
 
 	let firstDayOfMonth = currentDate.clone().startOf('month');
 	let lastDayOfMonth = currentDate.clone().endOf('month');
@@ -45,9 +45,9 @@ export function formatMonthDate(date, timeRange) {
 }
 
 export function formatWeekDate(date, timeRange) {
-	const currentDate = moment.utc(date);
-	const dateEnd = moment.utc(timeRange.dateEnd);
-	const dateStart = moment.utc(timeRange.dateStart);
+	const currentDate = moment(date);
+	const dateEnd = moment(timeRange.dateEnd);
+	const dateStart = moment(timeRange.dateStart);
 
 	let firstDayOfWeek = currentDate.clone().startOf('week');
 	let lastDayOfWeek = currentDate.clone().endOf('week');
@@ -76,9 +76,9 @@ export function formatWeekDate(date, timeRange) {
 }
 
 export function formatWeekDateWithYear(date, timeRange) {
-	const currentDate = moment.utc(date);
-	const dateEnd = moment.utc(timeRange.dateEnd);
-	const dateStart = moment.utc(timeRange.dateStart);
+	const currentDate = moment(date);
+	const dateEnd = moment(timeRange.dateEnd);
+	const dateStart = moment(timeRange.dateStart);
 
 	let firstDayOfWeek = currentDate.clone().startOf('week');
 	let lastDayOfWeek = currentDate.clone().endOf('week');
@@ -115,8 +115,8 @@ export function formatWeekDateWithYear(date, timeRange) {
 }
 
 export function getRangeKey(timeRange) {
-	const endDate = moment.utc(timeRange.dateEnd);
-	const startDate = moment.utc(timeRange.dateStart);
+	const endDate = moment(timeRange.dateEnd);
+	const startDate = moment(timeRange.dateStart);
 
 	const diff = parseInt(moment.duration(endDate.diff(startDate)).asDays());
 
@@ -139,7 +139,7 @@ export function getRangeKey(timeRange) {
 }
 
 export function formatXAxisDate(date, isAmPm, timeRangeKey, timeRange) {
-	const currentDate = moment.utc(date);
+	const currentDate = moment(date);
 	const rangeUnit = getRangeKey(timeRange);
 
 	if (timeRangeKey === HOURS) {
@@ -171,9 +171,9 @@ export function formatXAxisDate(date, isAmPm, timeRangeKey, timeRange) {
 }
 
 export function formatYearDate(date, timeRange) {
-	const currentDate = moment.utc(date);
-	const dateEnd = moment.utc(timeRange.dateEnd);
-	const dateStart = moment.utc(timeRange.dateStart);
+	const currentDate = moment(date);
+	const dateEnd = moment(timeRange.dateEnd);
+	const dateStart = moment(timeRange.dateStart);
 
 	let firstDayOfYear = currentDate.clone().startOf('year');
 	let lastDayOfYear = currentDate.clone().endOf('year');
@@ -245,10 +245,10 @@ export function getAxisMeasuresFromData(data) {
 }
 
 export function getXAxisIntervals(timeRange, keys, type) {
-	const endDate = moment.utc(timeRange.dateEnd);
+	const endDate = moment(timeRange.dateEnd);
 	const lengthKeys = keys.length;
-	const secondDate = moment.utc(keys[1]);
-	const startDate = moment.utc(timeRange.dateStart);
+	const secondDate = moment(keys[1]);
+	const startDate = moment(timeRange.dateStart);
 
 	const diffLeftDays = parseInt(
 		moment.duration(secondDate.diff(startDate)).asDays()
@@ -258,7 +258,7 @@ export function getXAxisIntervals(timeRange, keys, type) {
 		moment.duration(secondDate.diff(startDate)).asMonths()
 	);
 
-	const nextToLastDay = moment.utc(keys[lengthKeys - 2]);
+	const nextToLastDay = moment(keys[lengthKeys - 2]);
 
 	const diffRightDays = parseInt(
 		moment.duration(endDate.diff(nextToLastDay)).asDays()

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageTableItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/sla/list-page/SLAListPageTableItem.es.js
@@ -89,9 +89,7 @@ export default function Item({
 			<ClayTable.Cell>{durationString}</ClayTable.Cell>
 
 			<ClayTable.Cell>
-				{moment
-					.utc(dateModified)
-					.format(Liferay.Language.get('mmm-dd'))}
+				{moment(dateModified).format(Liferay.Language.get('mmm-dd'))}
 			</ClayTable.Cell>
 
 			<ClayTable.Cell className="actions">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/last-updated-info/MetricsCalculatedInfo.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/last-updated-info/MetricsCalculatedInfo.es.js
@@ -11,7 +11,7 @@ import moment from '../../util/moment.es';
 
 export default function MetricsCalculatedInfo({dateModified}) {
 	const date = dateModified
-		? moment.utc(dateModified).format(Liferay.Language.get('mmm-dd-lt'))
+		? moment(dateModified).format(Liferay.Language.get('mmm-dd-lt'))
 		: null;
 
 	const infoLabel = sub(Liferay.Language.get('sla-metrics-calculated'), [

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/util/date.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/util/date.es.js
@@ -8,7 +8,7 @@ import moment from './moment.es';
 const defaultDateFormat = 'YYYY-MM-DD\\THH:mm:ss\\Z';
 
 const formatDate = (date, format = 'L', fromFormat = null) => {
-	return moment.utc(date, fromFormat).format(format);
+	return moment(date, fromFormat).format(format);
 };
 
 const getLocaleDateFormat = (format = 'L') => {
@@ -31,7 +31,7 @@ const getMaskByDateFormat = (format) => {
 };
 
 const isValidDate = (date, format = 'L') => {
-	return moment.utc(date, format, true).isValid();
+	return moment(date, format, true).isValid();
 };
 
 export {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/shared/components/last-updated-info/MetricsCalculatedInfo.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/shared/components/last-updated-info/MetricsCalculatedInfo.es.js
@@ -12,9 +12,9 @@ import {MockRouter} from '../../../../test/mock/MockRouter.es';
 
 describe('MetricsCalculatedInfo', () => {
 	test.skip('will be correctly rendered', async () => {
-		const date = moment
-			.utc(new Date())
-			.format(Liferay.Language.get('mmm-dd-hh-mm-a'));
+		const date = moment(new Date()).format(
+			Liferay.Language.get('mmm-dd-hh-mm-a')
+		);
 
 		fetch.mockResolvedValueOnce({
 			json: () => Promise.resolve(date),


### PR DESCRIPTION
Ticket: [LPS-194915](https://liferay.atlassian.net/browse/LPS-194915)

Previously discussed on [PTR-4253](https://liferay.atlassian.net/browse/PTR-4253).

I saw that this resolved the issue in my testing. However, I'm not sure if this is the correct solution, because I'm not good with JavaScript, and I couldn't find as much information about the `moment` library as I would've liked.

I'm also not sure if this is actually using the user's configured time zone or the local machine's time zone instead. From what I saw in product, we typically render timestamps in `ThemeDisplay.getTimeZone()` ([source](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/util-taglib/src/com/liferay/taglib/search/DateSearchEntry.java#L81)), but I wasn't sure how to explicitly configure the `moment` library to use `ThemeDisplay.getTimeZone()`.

I'm also not sure if all the usages I updated actually need to be changed, or if only some subset of them do.