### PR TITLE
Reverting LPS-193988

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
@@ -163,23 +163,17 @@ export function parseReassignments(node) {
 export function parseNotifications(node) {
 	const notifications = {notificationTypes: [], recipients: []};
 
-	if (node.nodeName !== 'timer-notification') {
-		node.notifications.forEach((item) => {
-			notifications.executionType = parseProperty(
-				notifications,
-				item,
-				'execution-type'
-			);
-		});
-	}
-
 	node.notifications.forEach((item, index) => {
 		notifications.description = parseProperty(
 			notifications,
 			item,
 			'description'
 		);
-
+		notifications.executionType = parseProperty(
+			notifications,
+			item,
+			'execution-type'
+		);
 		notifications.name = parseProperty(notifications, item, 'name');
 
 		let notificationTypes = parseProperty(
@@ -386,7 +380,11 @@ export function parseNotifications(node) {
 			if (item.receptionType) {
 				notifications.recipients[index].push({
 					assignmentType: ['user'],
-					receptionType: [item.receptionType],
+					receptionType: [
+						item.receptionType[
+							notifications.recipients[index].length
+						],
+					],
 				});
 			}
 			else {
@@ -447,15 +445,7 @@ export function parseTimers(node) {
 				  })
 				: {}
 		);
-		taskTimers.timerNotifications.push(
-			node.taskTimers[index]['timer-notification']
-				? parseNotifications({
-						nodeName: 'timer-notification',
-						notifications:
-							node.taskTimers[index]['timer-notification'],
-				  })
-				: {}
-		);
+		taskTimers.timerNotifications.push({});
 		taskTimers.name = parseProperty(taskTimers, item, 'name');
 		taskTimers.description = parseProperty(taskTimers, item, 'description');
 		taskTimers.blocking = parseProperty(taskTimers, item, 'blocking');

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/xmlSchemaUtil.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/xmlSchemaUtil.js
@@ -88,7 +88,6 @@ function getLocationValue(field, context) {
 							if (item.children.length) {
 								let childNodesAttributes = [];
 								let grandChildren = [];
-								let grandGrandChildren = [];
 								let currentTagName;
 
 								for (const itemChild of item.children) {
@@ -141,8 +140,7 @@ function getLocationValue(field, context) {
 
 										break;
 									}
-
-									if (itemChild.children.length) {
+									else if (itemChild.children.length) {
 										if (!currentTagName) {
 											currentTagName = itemChild.tagName;
 										}
@@ -158,34 +156,21 @@ function getLocationValue(field, context) {
 											if (
 												itemGrandChild.children.length
 											) {
-												grandGrandChildren = [];
-
 												for (const grandGrand of itemGrandChild.children) {
 													const grandGrandContent = {};
 
 													grandGrandContent[
 														grandGrand.tagName
 													] = grandGrand.textContent;
-													grandGrandChildren.push(
+													grandChildren.push(
 														grandGrandContent
 													);
 												}
-
-												subItemContent[
-													itemGrandChild.tagName
-												] = grandGrandChildren;
 											}
 											else {
 												subItemContent[
 													itemGrandChild.tagName
 												] = itemGrandChild.textContent;
-											}
-
-											for (const itemGrandChildAttribute of itemGrandChild.attributes) {
-												subItemContent[
-													itemGrandChildAttribute.name
-												] =
-													itemGrandChildAttribute.value;
 											}
 										}
 										grandChildren.push(subItemContent);


### PR DESCRIPTION
Dear Team,

[LPS-193988](https://liferay.atlassian.net/browse/LPS-193988) causes the following regression:

Workflow definition with a reassignments > scripted-assignment cannot be saved because of a JS error that surfaces [here](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js#L154).

This is because of the modification made in [this commit](https://github.com/liferay/liferay-portal/commit/abfb988d40a72a9a3303af712a36d08686a2db05).
It will lead to the <script> node being embedded in a <scripted-assignment> node and the `parseReassignments(node)` function [won't be able to find it](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js#L96-L161).


Therefore, please revert LPS-193988.

Thank you and best regards,
István