### PR TITLE
[TS] LPS-198185 JS errors and Calendar not responding

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
@@ -274,10 +274,12 @@ AUI.add(
 						})
 					);
 
-					instance.items
-						.all(STR_DOT + CSS_CALENDAR_LIST_ITEM_ARROW)
-						.setAttribute('aria-expanded', false)
-						.setAttribute('aria-controls', simpleMenu.id);
+					if (simpleMenu) {
+						instance.items
+							.all(STR_DOT + CSS_CALENDAR_LIST_ITEM_ARROW)
+							.setAttribute('aria-expanded', false)
+							.setAttribute('aria-controls', simpleMenu.id);
+					}
 
 					contentBox.setContent(instance.items);
 				},


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When adding a Calendar widget to a page and setting the "Display Scheduler Only" option in the Display Settings, clicking the "Add Event" button throws JavaScript errors and nothing happens.
This is because `simpleMenu` will be `null` [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js#L280) and thus `defaultCalendar` won't be available [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js#L394).

Proposed Solution
========
Adding a null check for `simpleMenu` solves the issue.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.


Thank you and best regards,
István