### PR TITLE
LPS-200528 Make sure event is also available

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/js/main.js
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/js/main.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-AUI().use('escape', 'aui-lang', (A) => {
+AUI().use('escape', 'event', 'aui-lang', (A) => {
 	const AEscape = A.Escape;
 
 	const TPL_TAG_FORM =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-200528

## Steps to reproduce

1. Sign in as the portal administrator
2. Open the left-hand menu, go down to Configuration, and select Reports Admin
3. Navigate to the Definitions tab
4. Click on the + button to add a new Reports Definition
5. If you have SPA still enabled, refresh the page
6. Attempt to add a parameter

## Root cause analysis

Based on my own testing, the issue occurs because the call at the following line …

* https://github.com/liferay/liferay-portal-ee/blob/7.4.13-u100/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/js/main.js#L323-L325

… was failing to actually do anything. This conclusion is based on the output of adding a logging breakpoint to the minified version of the following line using the Developer Tools in the browser I used for testing (Chrome) …

* https://github.com/liferay/liferay-portal-ee/blob/7.4.13-u100/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/js/main.js#L327

… to check whether any listeners had been successfully attached. This was the content of the logging breakpoint:

```javascript
AUI().Event.getListeners(AUI().one(".parameters-key"), "valueChange")
```

The expectation is that we would get the one new EventHandle that had been added. The actual result is that there were still no EventHandle elements registered.

Since this only happens if SPA is disabled or if you refresh the page after visiting it, my conclusion is that it’s because something related to events is not available at the time the code runs. However, if you have SPA enabled, it might be available from some earlier page navigation.

## Solution notes

We don’t have any event related requirements listed in the current use list.

* https://github.com/liferay/liferay-portal-ee/blob/7.4.13-u100/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/js/main.js#L6

If we update that line, which currently reads …

```javascript
AUI().use('escape', 'aui-lang', (A) => {
```

… to instead read …

```javascript
AUI().use('escape', 'event', 'aui-lang', (A) => {
```

… that was sufficient to resolve the issue in my testing.