### PR TITLE
[CLDR] LPD-18592 Fix functional test AddCalendar#DefaultTimeZoneFollowsUserPreferences to work with CLDR locale provider

### DIFF
--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendar.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendar.testcase
@@ -326,13 +326,15 @@ definition {
 
 		Navigator.gotoNavNested(navNested = "Display Settings");
 
-		PortalSettings.configureTimeZone(timeZone = "(UTC -02:00) Fernando de Noronha Time");
+		Click.clickNoMouseOver(locator1 = "//option[@value='America/Noronha']");
+
+		PortalSettings._saveDisplaySettings();
 
 		Navigator.gotoPage(pageName = "Calendar Page");
 
 		CalendarNavigator.gotoAddMyCalendars();
 
-		Calendar.viewSelectedTimeZone(timeZone = "(UTC -02:00) Fernando de Noronha Time");
+		AssertElementPresent(locator1 = "//option[@value='America/Noronha' and @selected]");
 	}
 
 	@description = "LRQA-71360 - Verify that the name field is required"


### PR DESCRIPTION
Hi Team,

This is for https://liferay.atlassian.net/browse/LPD-18592
Our current java locale provider is JRE (jdk8 default)
In preparation to make the change to jdk21, we noticed that jdk21 default is CLDR. This made many functional tests fail because display name for timezone, country, format are slightly different.

In the case of this Calendar test: 
The testcase is looking for an option where the label text matches exactly with the text `(UTC -02:00) Fernando de Noronha Time` both to select and to check that it is selected later on.
This failed test case with CLDR because the label text changed.

Solution:
We can use timezoneId to locate the option with xpath and assert that it is clicked and selected instead.

This works both with JRE and CLDR

Testing here:
[With CLDR](https://github.com/julschong/liferay-portal/pull/1157)
[With JRE](https://github.com/julschong/liferay-portal/pull/1158)

Thank you!

