### PR TITLE
LPD-24258 - Avoid conflicts with the property Transition.name and the parameter name, the name that should be evaluated here is the one passed as parameter of the method _toTransition.

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/InstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/InstanceResourceImpl.java
@@ -1172,16 +1172,14 @@ public class InstanceResourceImpl extends BaseInstanceResourceImpl {
 	}
 
 	private Transition _toTransition(String name) {
-		Transition transition = new Transition() {
-			{
-				setLabel(
-					() -> _language.get(
-						ResourceBundleUtil.getModuleAndPortalResourceBundle(
-							contextAcceptLanguage.getPreferredLocale(),
-							InstanceResourceImpl.class),
-						name));
-			}
-		};
+		Transition transition = new Transition();
+
+		transition.setLabel(
+			() -> _language.get(
+				ResourceBundleUtil.getModuleAndPortalResourceBundle(
+					contextAcceptLanguage.getPreferredLocale(),
+					InstanceResourceImpl.class),
+				name));
 
 		transition.setName(() -> name);
 


### PR DESCRIPTION
  [LPD-24258](https://liferay.atlassian.net/browse/LPD-24258)
This bug was found during a routine analysis. The case still covered by the test: "WorkflowMetricsAllItemsListReassignTasks#BulkReassignConsiderFilteredResultsFromAllItemsPage"