### PR TITLE
LPD-33160

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetrics.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetrics.testcase
@@ -3210,66 +3210,6 @@ definition {
 			value1 = "There are no items assigned to users at the moment.");
 	}
 
-	@description = "LRQA-53630 Automate LPS-98518: [Dashboard] View workload distribution for all assignees"
-	@priority = 5
-	test ViewWorkloadByAssigneePage {
-		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		var siteName = TestCase.getSiteName(siteName = ${siteName});
-
-		WorkflowMetrics.createUsersAndAssignInstances(
-			numberOfBlogInstances = 4,
-			numberOfUsers = 3,
-			site = ${siteName});
-
-		WorkflowMetrics.goToWorkflowProcessMetrics(workflowProcessName = "Single Approver");
-
-		WorkflowMetrics.selectWorkloadByAssigneeCardFilterValue(workflowStep = "All Steps");
-
-		Click(
-			key_assigneesNumber = 3,
-			locator1 = "WorkflowMetrics#METRICS_PERFORMANCE_BY_ASSIGNEE_CARD_VIEW_ALL_ASSIGNEES_LINK");
-
-		WorkflowMetrics.viewWorkloadByAssigneePage(
-			assigneeName = "1user user1",
-			taskCount = 2);
-
-		WorkflowMetrics.viewWorkloadByAssigneePage(
-			assigneeName = "2user user2",
-			taskCount = 1);
-
-		WorkflowMetrics.viewWorkloadByAssigneePage(
-			assigneeName = "3user user3",
-			taskCount = 1);
-
-		WorkflowMetrics.viewUserWorkloadByStepOnAllItems(
-			assigneeName = "1user user1",
-			callingFrom = "PAGE",
-			isNotPresent = "2user user2,3user user3",
-			isPresent = "Blogs Entry Title 1,Blogs Entry Title 4",
-			taskName = "Review");
-
-		Navigator.gotoBack();
-
-		WorkflowMetrics.viewUserWorkloadByStepOnAllItems(
-			assigneeName = "2user user2",
-			callingFrom = "PAGE",
-			isNotPresent = "1user user1,3user user3",
-			isPresent = "Blogs Entry Title 2",
-			taskName = "Review");
-
-		Navigator.gotoBack();
-
-		WorkflowMetrics.viewUserWorkloadByStepOnAllItems(
-			assigneeName = "3user user3",
-			callingFrom = "PAGE",
-			isNotPresent = "1user user1,2user user2",
-			isPresent = "Blogs Entry Title 3",
-			taskName = "Review");
-	}
-
 	@description = "LRQA-58272 Automate LPS-107777: Move Workflow Metrics reindex actions out of the Search Settings"
 	@priority = 5
 	test WorkflowMetricsReindex {

--- a/modules/test/playwright/fixtures/workflowPagesTest.ts
+++ b/modules/test/playwright/fixtures/workflowPagesTest.ts
@@ -18,6 +18,7 @@ import {ProcessBuilderPage} from '../pages/portal-workflow-kaleo-designer-web/Pr
 import {SourceViewPage} from '../pages/portal-workflow-kaleo-designer-web/SourceViewPage';
 import {TimerPage} from '../pages/portal-workflow-kaleo-designer-web/TimerPage';
 import {MetricsPage} from '../pages/portal-workflow-metrics-web/MetricsPage';
+import {ProcessMetricsPage} from '../pages/portal-workflow-metrics-web/ProcessMetricsPage';
 import {WorkflowTaskDetailsPage} from '../pages/portal-workflow-task-web/WorkflowTaskDetailsPage';
 import {WorkflowTasksPage} from '../pages/portal-workflow-task-web/WorkflowTasksPage';
 import {WorkflowPage} from '../pages/portal-workflow-web/WorkflowPage';
@@ -33,6 +34,7 @@ const workflowPagesTest = test.extend<{
 	nodePropertiesSidebarPage: NodePropertiesSidebarPage;
 	notificationSectionPage: NotificationSectionPage;
 	processBuilderPage: ProcessBuilderPage;
+	processMetricsPage: ProcessMetricsPage;
 	scriptManagementPage: ScriptManagementPage;
 	sourceViewPage: SourceViewPage;
 	timerPage: TimerPage;
@@ -69,6 +71,9 @@ const workflowPagesTest = test.extend<{
 	},
 	processBuilderPage: async ({page}, use) => {
 		await use(new ProcessBuilderPage(page));
+	},
+	processMetricsPage: async ({page}, use) => {
+		await use(new ProcessMetricsPage(page));
 	},
 	scriptManagementPage: async ({page}, use) => {
 		await use(new ScriptManagementPage(page));

--- a/modules/test/playwright/fixtures/workflowPagesTest.ts
+++ b/modules/test/playwright/fixtures/workflowPagesTest.ts
@@ -17,6 +17,7 @@ import {NotificationSectionPage} from '../pages/portal-workflow-kaleo-designer-w
 import {ProcessBuilderPage} from '../pages/portal-workflow-kaleo-designer-web/ProcessBuilderPage';
 import {SourceViewPage} from '../pages/portal-workflow-kaleo-designer-web/SourceViewPage';
 import {TimerPage} from '../pages/portal-workflow-kaleo-designer-web/TimerPage';
+import {AllItemsPage} from '../pages/portal-workflow-metrics-web/AllItemsPage';
 import {MetricsPage} from '../pages/portal-workflow-metrics-web/MetricsPage';
 import {ProcessMetricsPage} from '../pages/portal-workflow-metrics-web/ProcessMetricsPage';
 import {WorkflowTaskDetailsPage} from '../pages/portal-workflow-task-web/WorkflowTaskDetailsPage';
@@ -26,6 +27,7 @@ import {WorkflowPage} from '../pages/portal-workflow-web/WorkflowPage';
 const workflowPagesTest = test.extend<{
 	actionPage: ActionPage;
 	actionReassignmentPage: ActionReassignmentPage;
+	allItemsPage: AllItemsPage;
 	conditionNode: ConditionNode;
 	configurationTabPage: ConfigurationTabPage;
 	definitionInfoPage: DefinitionInfoPage;
@@ -47,6 +49,9 @@ const workflowPagesTest = test.extend<{
 	},
 	actionReassignmentPage: async ({page}, use) => {
 		await use(new ActionReassignmentPage(page));
+	},
+	allItemsPage: async ({page}, use) => {
+		await use(new AllItemsPage(page));
 	},
 	conditionNode: async ({page}, use) => {
 		await use(new ConditionNode(page));

--- a/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
@@ -52,16 +52,6 @@ type TServices = {
 	serviceType: string;
 };
 
-type TUserAccount = {
-	alternateName?: string;
-	emailAddress?: string;
-	familyName?: string;
-	givenName?: string;
-	id?: string;
-	name?: string;
-	password?: string;
-};
-
 type TExportBatch = {
 	className?: string;
 	contentType?: string;

--- a/modules/test/playwright/helpers/HeadlessAdminWorkflowApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminWorkflowApiHelper.ts
@@ -26,6 +26,27 @@ export class HeadlessAdminWorkflowApiHelper {
 		)) as WorkflowDefinition;
 	}
 
+	async getWorkflowTasksBySubmittingUser(
+		creatorId: number,
+		pageSize?: number
+	) {
+		return await this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${this.basePath}/workflow-tasks/submitting-user?creatorId=${creatorId}` +
+				(pageSize ? `&pageSize=${pageSize}` : '')
+		);
+	}
+
+	async postAssignTaskToUser(workflowTaskId: number, assigneeId: number) {
+		return await this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/workflow-tasks/${workflowTaskId}/assign-to-user`,
+			{
+				data: {
+					assigneeId,
+				},
+			}
+		);
+	}
+
 	async postWorkflowDefinitionSave(
 		name: string,
 		workflowDefinition: Partial<WorkflowDefinition>

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -76,6 +76,12 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async deleteBlog(blogId: number) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/blog-postings/${blogId}`
+		);
+	}
+
 	async deleteDocument(documentId: string) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/documents/${documentId}`

--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -23,8 +23,7 @@ export class ConfigurationTabPage {
 
 	async goTo() {
 		await this.processBuilderPage.goto();
-		await this.configurationTabLink.waitFor({state: 'visible'});
-		await this.configurationTabLink.click({force: true});
+		await this.configurationTabLink.click();
 		await this.page.waitForURL((url) =>
 			url.href.includes('=configuration')
 		);

--- a/modules/test/playwright/pages/portal-workflow-metrics-web/AllItemsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-metrics-web/AllItemsPage.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class AllItemsPage {
+	readonly page: Page;
+	readonly backButton: Locator;
+	readonly pendingFilterLabel: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.backButton = this.page.locator('#backButton').getByRole('link');
+		this.pendingFilterLabel = this.page.getByText(
+			'Process Status: Pending'
+		);
+	}
+}

--- a/modules/test/playwright/pages/portal-workflow-metrics-web/ProcessMetricsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-metrics-web/ProcessMetricsPage.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class ProcessMetricsPage {
+	readonly page: Page;
+	readonly viewAllAssigneesButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.viewAllAssigneesButton = this.page.getByText('View All Assignees');
+	}
+}

--- a/modules/test/playwright/tests/portal-workflow-task-web/workload.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/workload.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {notificationPagesTest} from '../../fixtures/notificationPagesTest';
+import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import clearInvalidUserNotifications from '../../utils/clearInvalidUserNotifications';
+import retryGetWorkflowTasksBySubmittingUser from '../../utils/retryGetWorkflowTasksBySubmittingUser';
+import {blogsPagesTest} from '../blogs-web/fixtures/blogsPagesTest';
+
+export const test = mergeTests(
+	applicationsMenuPageTest,
+	apiHelpersTest,
+	blogsPagesTest,
+	loginTest(),
+	notificationPagesTest,
+	workflowPagesTest
+);
+
+interface CreatedEntities {
+	blogPosts?: TBlogPost[];
+	users?: TUserAccount[];
+}
+
+const createdEntities: CreatedEntities = {};
+
+test.afterEach(async ({apiHelpers, configurationTabPage, page}) => {
+	await configurationTabPage.goTo();
+
+	await configurationTabPage.unassignWorkflowFromAssetType('Blogs Entry');
+
+	if (createdEntities.users?.length) {
+		for (const user of createdEntities.users) {
+			await apiHelpers.headlessAdminUser.deleteUserAccount(
+				Number(user.id)
+			);
+		}
+	}
+
+	delete createdEntities.users;
+
+	if (createdEntities.blogPosts?.length) {
+		for (const blog of createdEntities.blogPosts) {
+			await apiHelpers.headlessDelivery.deleteBlog(blog.id);
+		}
+	}
+
+	delete createdEntities.blogPosts;
+
+	await clearInvalidUserNotifications(page);
+});
+
+test('view workload distribution for all assignees', async ({
+	allItemsPage,
+	apiHelpers,
+	applicationsMenuPage,
+	configurationTabPage,
+	metricsPage,
+	page,
+}) => {
+	const NEW_PAGE_SIZE = 4;
+	const NUMBER_OF_USERS_AND_TASKS = 5;
+	const WORKFLOW_DEFINITION_NAME = 'Single Approver';
+
+	const blogPosts = [];
+	const users = [];
+
+	await configurationTabPage.goTo();
+
+	await configurationTabPage.assignWorkflowToAssetType(
+		WORKFLOW_DEFINITION_NAME,
+		'Blogs Entry'
+	);
+
+	const portalContentReviewerRole = await apiHelpers.headlessAdminUser
+		.getRoles('"Portal Content Reviewer"')
+		.then(({items}) => items[0]);
+
+	const site = await apiHelpers.headlessSite.getSiteByERC('L_GUEST');
+
+	for (let index = 0; index < NUMBER_OF_USERS_AND_TASKS; index++) {
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		await apiHelpers.headlessAdminUser.assignUserToRole(
+			portalContentReviewerRole.externalReferenceCode,
+			user.id
+		);
+
+		users.push(user);
+
+		const blogPost = await apiHelpers.headlessDelivery.postBlog(site.id);
+
+		blogPosts.push(blogPost);
+	}
+
+	createdEntities.users = users;
+
+	createdEntities.blogPosts = blogPosts;
+
+	const submittingUser = blogPosts[0].creator.id;
+
+	const workflowTaskDefinitions = await retryGetWorkflowTasksBySubmittingUser(
+		{
+			expectedNumberOfTasks: NUMBER_OF_USERS_AND_TASKS,
+			page,
+			submittingUser,
+		}
+	);
+
+	for (let index = 0; index < NUMBER_OF_USERS_AND_TASKS; index++) {
+		await apiHelpers.headlessAdminWorkflow.postAssignTaskToUser(
+			workflowTaskDefinitions.items[index].id,
+			users[index].id
+		);
+	}
+
+	await applicationsMenuPage.goToMetrics();
+
+	await metricsPage.chooseProcess(WORKFLOW_DEFINITION_NAME);
+
+	for (const user of users) {
+		await expect(page.getByText(user.name)).toBeVisible();
+	}
+
+	await page
+		.getByText(`View All Assignees (${NUMBER_OF_USERS_AND_TASKS})`)
+		.click();
+
+	await expect(
+		page.getByText(`${WORKFLOW_DEFINITION_NAME}: Workload by Assignee`)
+	).toBeVisible();
+
+	await expect(
+		page.getByText(
+			`Showing 1 to ${NUMBER_OF_USERS_AND_TASKS} of ${NUMBER_OF_USERS_AND_TASKS} entries.`
+		)
+	).toBeVisible();
+
+	await page.getByLabel('Items Per Page').click();
+
+	await page.getByRole('option', {name: `${NEW_PAGE_SIZE} Entries`}).click();
+
+	await expect(
+		page.getByText(
+			`Showing 1 to ${NEW_PAGE_SIZE} of ${NUMBER_OF_USERS_AND_TASKS} entries.`
+		)
+	).toBeVisible();
+
+	for (const [index, user] of users.entries()) {
+		const assigneeLink = page.getByText(user.name);
+
+		await expect(assigneeLink).toBeVisible();
+
+		await assigneeLink.click();
+
+		await expect(
+			page.getByText(`${WORKFLOW_DEFINITION_NAME}: All Items`)
+		).toBeVisible();
+
+		await expect(page.getByText(`Assignee: ${user.name}`)).toBeVisible();
+
+		await expect(allItemsPage.pendingFilterLabel).toBeVisible();
+
+		await allItemsPage.backButton.click();
+
+		if (index === NEW_PAGE_SIZE - 1) {
+			await page.getByLabel('Go to the next page,').click();
+		}
+	}
+});

--- a/modules/test/playwright/types/account.d.ts
+++ b/modules/test/playwright/types/account.d.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type TUserAccount = {
+	alternateName?: string;
+	emailAddress?: string;
+	familyName?: string;
+	givenName?: string;
+	id?: string;
+	name?: string;
+	password?: string;
+};

--- a/modules/test/playwright/types/blog.d.ts
+++ b/modules/test/playwright/types/blog.d.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay; Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type TBlogPost = {
+	articleBody: string;
+	creator?: TBlogCreator;
+	externalReferenceCode: string;
+	headline: string;
+	id: number;
+};
+
+type TBlogCreator = {
+	additionalName: string;
+	contentType: string;
+	familyName: string;
+	givenName: string;
+	id: number;
+	name: string;
+};

--- a/modules/test/playwright/types/workflow.d.ts
+++ b/modules/test/playwright/types/workflow.d.ts
@@ -39,3 +39,25 @@ interface WorkflowDefinition {
 	title_i18n: DataObject;
 	version: string;
 }
+
+interface WorkflowTaskDefinition {
+	completed: boolean;
+	description: string;
+	id: number;
+	label: string;
+	name: string;
+	objectReviewed: {
+		assetTitle: string;
+		assetType: string;
+		id: number;
+		resourceType: string;
+	};
+	workflowDefinitionId: number;
+	workflowDefinitionName: string;
+	workflowDefinitionVersion: string;
+	workflowInstanceId: number;
+}
+
+interface WorkflowTaskDefinitions {
+	items: WorkflowTaskDefinition[];
+}

--- a/modules/test/playwright/utils/clearInvalidUserNotifications.ts
+++ b/modules/test/playwright/utils/clearInvalidUserNotifications.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+export default async function (page: Page) {
+	await page.getByTitle('User Profile Menu').click();
+
+	await page.getByRole('menuitem', {name: 'Notifications'}).click();
+
+	await page.waitForLoadState('networkidle');
+
+	await expect(
+		page.getByRole('heading', {name: 'Notifications'})
+	).toBeVisible();
+
+	while (
+		(await page.getByText('Notification no longer applies.').count()) > 0
+	) {
+		await page.reload();
+
+		if (
+			(await page
+				.getByText('Notification no longer applies.')
+				.count()) === 0
+		) {
+			break;
+		}
+	}
+}

--- a/modules/test/playwright/utils/retryGetWorkflowTasksBySubmittingUser.ts
+++ b/modules/test/playwright/utils/retryGetWorkflowTasksBySubmittingUser.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {ApiHelpers} from '../helpers/ApiHelpers';
+
+type Params = {
+	expectedNumberOfTasks: number;
+	page: Page;
+	retryInterval?: number;
+	retryLimit?: number;
+	submittingUser: number;
+};
+
+/**
+ * Workflow tasks are dynamically generated in the back-end whenever an asset assigned to a workflow is
+ * created. Due to this, there is a delay between the creation of an asset and the availability of
+ * its corresponding task.
+ *
+ * This function repeatedly retrieves tasks until the expected amount is returned.
+ */
+export default async function ({
+	expectedNumberOfTasks,
+	page,
+	retryInterval = 500,
+	retryLimit = 10,
+	submittingUser,
+}: Params): Promise<WorkflowTaskDefinitions> {
+	const apiHelpers = new ApiHelpers(page);
+	let workflowTasks: WorkflowTaskDefinitions;
+	let attempt = 0;
+
+	while (attempt < retryLimit) {
+		workflowTasks =
+			await apiHelpers.headlessAdminWorkflow.getWorkflowTasksBySubmittingUser(
+				submittingUser,
+				-1
+			);
+
+		if (workflowTasks?.items?.length === expectedNumberOfTasks) {
+			return workflowTasks;
+		}
+
+		attempt++;
+
+		if (retryInterval) {
+			await new Promise((resolve) => setTimeout(resolve, retryInterval));
+		}
+	}
+
+	throw new Error(
+		`Failed to retrieve the expected number of tasks after ${retryLimit} attempts.`
+	);
+}


### PR DESCRIPTION
I noticed that tests that use `await configurationTabPage.goTo();` in afterEach had difficulty passing the IC on the first attempt and are marked as flaky tests, highlighting an error in waitFor. For exemple:

workload.spec.ts/[view workload distribution for all assignees](https://ff7b1de552e11d29c7e2f2a7982466d05226767410b1d3ed5d2807c-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2024-08%2Ftest-1-28%2Ftest-portal-acceptance-pullrequest(master)%2F10754%2Fplaywright-js-tomcat90-mysql57-jdk8%2F38%2F0%2Fplaywright-report%2Findex.html?jk=AXZI6Jz1L30FIcaWYa8voX0qDlSOp5Xm8fxWeRCrfYL49lvJreGhHZdvtkqfztfOIZZYiKSURdW8y3ugKhuIVBdyiUjP_ph-rj2XP0674QFKPrlvRjDCBlhCvuBVVphBQP2nXUx6lRicc2DIFHbX5W3ZwVPqOQjjAsUIENNWV6-7_dvjHfryDCZ-Co-XP-oX4wnvuxd5bbESj0nIO0bbYPsglFxqP4zutLSxci4aY679ZG7LfeTtbRUmdnmdbam8aF3s_Llwo5vGRSVsAulqIU8xxw0lVKN0kMmaoQZB2V-FSXECwvfrG2jYpFGDvf2lppywDjLWtOlYC3Ai2fbMT0oAguZtxrwr25I0P-4-W4E3GZwFxwRUhNueZeOnMUlV1F0rzy537zeKAkBxi_GofQNO9OrV0jWEVYUMDzJxBMbYSoBVkQm-c011tHvURFaG6ihmirAsBTMLT97uVu-UQsGKl1NigjjZoDPVmomqC_7-66_4-M1titKOtp2OnOxyeNCXxa8xmw0UiPyAfnjQJliJOGGpHqndMFNZgyz-0HynETtfSuDPpjKRl8FkwmBxzP_ykMG8YDQxSOmAbr6sdVgXw_NXW7G-ld3-IOrzBtmariZjztcMQTvcG0q3vWaRojY9dzxAwYHIdiChwvlD5OOod-m7oM7QChezLCZmWXjVi1mcr4UPTqUzeE5wrBzw-jM0L50Co-euMWvoQsF9rG2TiS2kHowx1k_nBu_ZSYzv0vrUKOmaWX_DLljPt9b93CIF7ePOXSAYfjkm3whzwE6RWiEo6gZRbOR2-1tbVLWBFUW19yb10lDS5b9IhVBufmZ5hJ9GwhKXVsENr640dbruYtXLojAqVvVeKHi2cdc_cthjrNfq7SMkpCQAHclKQPr0Cr6BGdH289qwNqHrCSV6aYQ8JRezQs2lK5NZurnBMMOQwUqu_VSQ2Ki1eCC0drOD4ao5QAYNskbC8TbHsBqtIIcnd9MPZ-EToAoLsK6NP0_nbZ9MvgSvsyBrnlAsbYMGHwi59RCApwm2WoLcCLTLz8pdQMjytmF3BIQfbyXB7TtBOfFxcOnVCTR8KRFawi88FVfbT7B2eDDz0lXaQOWel-m4OqHz_PK0PffvceeCM3Ts58YXn2YW5WC1izlz1FVx_o03EzOFahFJlp7rPeHNlJAispBvR1hmiaHP9Ot1CKzyyiAc7amyJa-_MQ1sZZD3tlCsh3uFGcwNLH2UTVobih61tEqBS5KpOizrw23BXugACjZb--qy1VWoTjKkCeEUV7WBseumaHVnGsQwoKH0-bOJUxeO3lrm-LiZk4jFtP0&isca=1#?testId=c35e296e71d734c67754-e27cf5b59f6f71a53362)
userNotification.spec.ts/[review comment is added to user notification](https://ffa7d7ba08a767ff86bd202f5c5f68337f4f8dedc2d90acbbd75a05-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2024-08%2Ftest-1-28%2Ftest-portal-acceptance-pullrequest(master)%2F10754%2Fplaywright-js-tomcat90-mysql57-jdk8%2F10%2F0%2Fplaywright-report%2Findex.html?jk=AXZI6JxryjqkMMLAmOYaqBgFy7JEhd05ZlCCHLSPZgsGmnZ7Ou_yzaZcA_XljckEsJygfQopt_CERHy21_QXDbI2GDz-oY9KAz8GHSm2AYfPYU2yIsVVfXRfeCjlnJGdGQm8HXIHabzgsSoaaPR9fApOR9FBIOAKtB8Axe0M9ncaQD4D1bKaop5EXaaZl6HQHLNhczCBURY-HtS4YDEsKbFrEp-Adw_w9mIDaDMidl7o2-coc8YqhhrRoVcm4ecdn26JT6IVTM11vTRJg4Hf7-WPTEJUt4yMlgNReNTyvqiHB7eA92EeSsmktyeN62Jj-qPUAb8s1gzYuTaA-7Fs6eKdtFvlqbcmjymrBuQRmuHHdiVBGeesPdiVA0t4_UswSbHt05FRI3mwtQWDiq0cO1SoCUaUjxM7rE_0qBo0ciGYRf1drk6QgPPa28xQDpre_4hqI1S1HtdEu0aDuBUomyaKAvbQ9Bs_5hIEcNVbvZz7at9udBGulpTPkNbKEm2rvJ6p4V1AKJ2LJvK155K4eVz2XKJtNZ5nyR9yvM1838F35xr2-aWyko9XfTv2G8sWhFUmmCjQlg6lhLX-_Omoiu6sd3myutfcRFxMT-Wgx5rq6C4hvECoE6DjkClFpv7FX5bLYcOHBnOhaFVCdPDRfDrjame0Abd2AtfxSjW4PPIFhG1P1jW_xdmBYYHmCkccrH3YlE7ZLbIsqOIjujMXdoVVGtUdzBADYTmWyUPvneYn8sqemHwQmOI423xX6p9Jb-Ty8QEfyR0MUNsBXS7YJmEaHlO_VbhZIhI6dKARF1-Md5ppN3GFG9PfDjmS-YfDXVGjnOJo_6PwG3-CbGAfpDMaDyLeFxz9xexF3HyCLZx3StYWWq4WJgsEg5LtAz1iCs-FP8mk795IwG2PDc6gAI9xZOD3z9ThDEieK95UMoCfpiaTlUYHDF6MdO7RHgMcdatikEthO5K10xHNXkTuaNsVht7eegEKPAw6Bhr5VKC9tmspKg1HWvMr1a2tlHNxDJkpvVkZALQaprgKU7_ZIEgEBO7mSD-fi9-IIvzL-mkQtRbD9kJuVRS5g8DRzoOZFcjxNQ6m9lU-XMPuO9mADFWZPppbYwrBci4brZqU4UfrtCNR3OYBuXIiEora54lWegBJKCuvcH_IbkkVNxMrLE3QxlJzhs1KvoGlkeHU3rto7qcccw4Y-8Ab3XaTRfpOgYVZ2Vw5A3n53AF7YrybWApbZbNVPn10POytso_mDJbIVCMXzHF2BqXXh3mY1OFyB1Jkgni56kJ1SnK7enwo22p9CESrrHYDulEU_MzdtCbuBqeP&isca=1#?testId=306c2b323ec99ae53b47-fe7bcf3c13ca5fe20c94)

According to the playwright documentation, before executing the click action we perform a series of checks:

- wait for element with given selector to be in DOM
- wait for it to become displayed, i.e. not empty, no display:none, no visibility:hidden
- wait for it to stop moving, for example, until css transition finishes
- scroll the element into view
- wait for it to receive pointer events at the action point, for example, waits until element becomes non-obscured by other elements
- retry if the element is detached during any of the above checks

I did local tests and when removing waitFor I could not notice any harm in the execution of the tests.

Furthermore, I noticed that the documentation suggests using click with the force property for the following case:

> Sometimes, apps use non-trivial logic where hovering the element overlays it with another element that intercepts the click. This behavior is indistinguishable from a bug where element gets covered and the click is dispatched elsewhere. If you know this is taking place, you can bypass the [actionability](https://playwright.dev/docs/actionability) checks and force the click

This is not the case with this button. In local tests, removing this property from the click did not cause any harm to the test execution.

My goal with this PR is to test whether the proposed changes removed the flaky status from tests that use the modified function in afterEach.