### PR TITLE
LPD-33901 Use role name in workflow xml definition

### DIFF
--- a/modules/apps/account/account-test/src/testFunctional/macros/Account.macro
+++ b/modules/apps/account/account-test/src/testFunctional/macros/Account.macro
@@ -1063,7 +1063,7 @@ definition {
 
 	@summary = "Default summary"
 	macro grantUserAccessToAccountAdmin(userEmailAddress = null) {
-		JSONRole.addRegularRole(roleTitle = "Access Account Permission");
+		JSONRole.addRegularRole(roleKey = "Access Account Permission");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ACCESS_IN_CONTROL_PANEL",
@@ -1238,7 +1238,7 @@ definition {
 
 	@summary = "Default summary"
 	macro setAddAccountEntryPermissions(roleTitle = null, userEmailAddress = null) {
-		JSONRole.addRegularRole(roleTitle = ${roleTitle});
+		JSONRole.addRegularRole(roleKey = ${roleTitle});
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ADD_ACCOUNT_ENTRY",

--- a/modules/apps/account/account-test/src/testFunctional/tests/AccountGroups.testcase
+++ b/modules/apps/account/account-test/src/testFunctional/tests/AccountGroups.testcase
@@ -44,7 +44,7 @@ definition {
 			}
 
 			task ("And A new Regular role with Update permission exists") {
-				JSONRole.addRegularRole(roleTitle = "Only Update Permission");
+				JSONRole.addRegularRole(roleKey = "Only Update Permission");
 
 				Permissions.definePermissionViaJSONAPI(
 					resourceAction = "VIEW_CONTROL_PANEL",
@@ -107,7 +107,7 @@ definition {
 				userEmailAddress = "userea1@liferay.com");
 
 			task ("And A new Regular role with Access in Control Panel permission exists") {
-				JSONRole.addRegularRole(roleTitle = "View AG Reg Role");
+				JSONRole.addRegularRole(roleKey = "View AG Reg Role");
 
 				Permissions.definePermissionViaJSONAPI(
 					resourceAction = "VIEW_CONTROL_PANEL",
@@ -160,7 +160,7 @@ definition {
 				accountGroupName = "AG Name with Accounts");
 
 			task ("And A new Regular role with assign account permission exists") {
-				JSONRole.addRegularRole(roleTitle = "Assign Account Reg Role");
+				JSONRole.addRegularRole(roleKey = "Assign Account Reg Role");
 
 				Permissions.definePermissionViaJSONAPI(
 					resourceAction = "VIEW_CONTROL_PANEL",
@@ -658,7 +658,7 @@ definition {
 				accountGroupName = "AG Name with Accounts");
 
 			task ("And A new Regular role with assign account permission") {
-				JSONRole.addRegularRole(roleTitle = "Assign Account Reg Role");
+				JSONRole.addRegularRole(roleKey = "Assign Account Reg Role");
 
 				Permissions.definePermissionViaJSONAPI(
 					resourceAction = "VIEW_CONTROL_PANEL",
@@ -734,7 +734,7 @@ definition {
 				accountGroupName = "AG Name with Accounts");
 
 			task ("And A new Regular role with view account permission exists") {
-				JSONRole.addRegularRole(roleTitle = "View Account Reg Role");
+				JSONRole.addRegularRole(roleKey = "View Account Reg Role");
 
 				Permissions.definePermissionViaJSONAPI(
 					resourceAction = "VIEW_CONTROL_PANEL",
@@ -805,7 +805,7 @@ definition {
 				requireReset = "false",
 				userEmailAddress = "userea@liferay.com");
 
-			JSONRole.addRegularRole(roleTitle = "Update and View Account Groups");
+			JSONRole.addRegularRole(roleKey = "Update and View Account Groups");
 
 			JSONRole.assignRoleToUser(
 				roleTitle = "Update and View Account Groups",

--- a/modules/apps/account/account-test/src/testFunctional/tests/AccountPermissions.testcase
+++ b/modules/apps/account/account-test/src/testFunctional/tests/AccountPermissions.testcase
@@ -569,7 +569,7 @@ definition {
 				userLastName = "userln1",
 				userScreenName = "usersn1");
 
-			JSONRole.addRegularRole(roleTitle = "Edit User Role");
+			JSONRole.addRegularRole(roleKey = "Edit User Role");
 
 			for (var resourceActionIndex : list "UPDATE,VIEW") {
 				Permissions.definePermissionViaJSONAPI(

--- a/modules/apps/account/account-test/src/testFunctional/tests/AccountRoles.testcase
+++ b/modules/apps/account/account-test/src/testFunctional/tests/AccountRoles.testcase
@@ -75,7 +75,7 @@ definition {
 		}
 
 		task ("And creates a new Regular role, assigning AccountMgr1 to the role") {
-			JSONRole.addRegularRole(roleTitle = "AccountRole1 Role Manager");
+			JSONRole.addRegularRole(roleKey = "AccountRole1 Role Manager");
 
 			JSONRole.assignRoleToUser(
 				roleTitle = "AccountRole1 Role Manager",

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
@@ -369,7 +369,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",
@@ -1169,7 +1169,7 @@ definition {
 			depotName = "Test Depot Name",
 			userEmailAddress = "userea2@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",
@@ -1222,7 +1222,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSelectAndDeselectScopeFromCollectionsPermissions {
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "DELETE",
@@ -1272,7 +1272,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSelectAndDeselectScopeFromDMPermissions {
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ADD_DOCUMENT",
@@ -1322,7 +1322,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSelectAndDeselectScopeFromWCPermissions {
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "VIEW",
@@ -1385,7 +1385,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",
@@ -1578,7 +1578,7 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewScopeFromUnsupportedApplicationPermissions {
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		Role.openRolesAdmin();
 
@@ -1627,7 +1627,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRoles.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRoles.testcase
@@ -48,7 +48,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testFunctional/tests/GoogleDrive.testcase
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testFunctional/tests/GoogleDrive.testcase
@@ -862,7 +862,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Regular Role",

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/RoleDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/RoleDTOConverter.java
@@ -76,7 +76,7 @@ public class RoleDTOConverter
 						role.getDescriptionMap()));
 				setExternalReferenceCode(role::getExternalReferenceCode);
 				setId(role::getRoleId);
-				setName(() -> role.getTitle(dtoConverterContext.getLocale()));
+				setName(role::getName);
 				setName_i18n(
 					() -> LocalizedMapUtil.getI18nMap(role.getTitleMap()));
 				setRolePermissions(

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectActions.testcase
@@ -1251,7 +1251,7 @@ definition {
 		}
 
 		task ("When the user creates a regular role and navigates to the role permissions") {
-			JSONRole.addRegularRole(roleTitle = "Regular Role");
+			JSONRole.addRegularRole(roleKey = "Regular Role");
 
 			Role.openRolesAdmin();
 
@@ -1949,7 +1949,7 @@ definition {
 		}
 
 		task ("When the user is given permission to trigger a standalone action") {
-			JSONRole.addRegularRole(roleTitle = "Regular Role");
+			JSONRole.addRegularRole(roleKey = "Regular Role");
 
 			Role.openRolesAdmin();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectCustomLayouts.testcase
@@ -763,7 +763,7 @@ definition {
 				userLastName = "userln",
 				userScreenName = "usersn");
 
-			JSONRole.addRegularRole(roleTitle = "Regular Role");
+			JSONRole.addRegularRole(roleKey = "Regular Role");
 
 			var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 
@@ -892,7 +892,7 @@ definition {
 				userLastName = "userln",
 				userScreenName = "usersn");
 
-			JSONRole.addRegularRole(roleTitle = "Regular Role");
+			JSONRole.addRegularRole(roleKey = "Regular Role");
 
 			var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotifications.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectNotifications.testcase
@@ -88,7 +88,7 @@ definition {
 				userLastName = "userln",
 				userScreenName = "usersn");
 
-			JSONRole.addRegularRole(roleTitle = "Regular Role");
+			JSONRole.addRegularRole(roleKey = "Regular Role");
 
 			JSONRole.assignRoleToUser(
 				roleTitle = "Regular Role",

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectPermission.testcase
@@ -26,7 +26,7 @@ definition {
 	@description = "LPS-135390 - Verify it is possible to view and access the Picklist portlet with the Access in Control Panel permission"
 	@priority = 4
 	test CanAccessPicklistWithAccessPermission {
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(
@@ -68,7 +68,7 @@ definition {
 	@description = "LPS-135390 - Verify it is possible to add a Picklist with the Add permission"
 	@priority = 4
 	test CanAddPicklistWithAddPermission {
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(
@@ -495,7 +495,7 @@ definition {
 	test CannotAddPicklistWithoutAddPermission {
 		property portal.acceptance = "true";
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(
@@ -623,7 +623,7 @@ definition {
 
 		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 
@@ -730,7 +730,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ACCESS_IN_CONTROL_PANEL",
@@ -886,7 +886,7 @@ definition {
 
 		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 
@@ -965,7 +965,7 @@ definition {
 
 		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 
@@ -1332,7 +1332,7 @@ definition {
 
 		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		var objectId = JSONObject.getObjectId(objectName = "CustomObject");
 
@@ -1391,7 +1391,7 @@ definition {
 	test CannotViewPicklistWithoutViewPermission {
 		Picklist.addPicklistViaAPI(picklistName = "Picklist Test");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(
@@ -1968,7 +1968,7 @@ definition {
 	@description = "LPS-140342 - Verify it is possible view and edit its own Picklist with only the Add Picklist permission"
 	@priority = 4
 	test CanViewAndEditPicklistWithAddPicklistPermission {
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(
@@ -2093,7 +2093,7 @@ definition {
 	test CanViewPicklistWithViewPermission {
 		Picklist.addPicklistViaAPI(picklistName = "Picklist Test");
 
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(

--- a/modules/apps/object/object-test/src/testFunctional/tests/SystemObjectAccount.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/SystemObjectAccount.testcase
@@ -473,7 +473,7 @@ definition {
 	@description = "LPS-151765 - Verify if is possible a Custom User to view the System Object Account, if it to have permission"
 	@priority = 4
 	test CanUserViewSystemAccountWhenAllowed {
-		JSONRole.addRegularRole(roleTitle = "Regular Role");
+		JSONRole.addRegularRole(roleKey = "Regular Role");
 
 		for (var resourceAction : list "ACCESS_IN_CONTROL_PANEL,VIEW") {
 			Permissions.definePermissionViaJSONAPI(

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsPermissions.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsPermissions.testcase
@@ -111,7 +111,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Regrole Name",

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoformsUsecase.testcase
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoformsUsecase.testcase
@@ -524,7 +524,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "KaleoRegRole Name");
+		JSONRole.addRegularRole(roleKey = "KaleoRegRole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "KaleoRegRole Name",
@@ -1051,7 +1051,7 @@ definition {
 
 		var siteName = TestCase.getSiteName(siteName = ${siteName});
 
-		JSONRole.addRegularRole(roleTitle = "KaleoRegRole Name");
+		JSONRole.addRegularRole(roleKey = "KaleoRegRole Name");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ACCESS_IN_CONTROL_PANEL",
@@ -1201,7 +1201,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "KaleoRegRole Name");
+		JSONRole.addRegularRole(roleKey = "KaleoRegRole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "KaleoRegRole Name",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/ProcessBuilderKaleoDesignerReact.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/ProcessBuilderKaleoDesignerReact.testcase
@@ -4845,7 +4845,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given a regular role with multi-byte characters in the title") {
+		task ("Given a regular role with multi-byte characters in the name") {
 			JSONRole.addRegularRole(
 				roleKey = "テスト",
 				roleTitle = "test");
@@ -4873,7 +4873,7 @@ definition {
 				key_direction = "right");
 		}
 
-		task ("When publishing workflow definition with node task assigned to regular role with multibyte characters in title") {
+		task ("When publishing workflow definition with node task assigned to regular role with multibyte characters in name") {
 			ProcessBuilderKaleoDesignerReact.selectNode(nodeType = "task");
 
 			ProcessBuilderKaleoDesignerReact.viewAndFillAssignments(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/assignments/Assignments.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/assignments/Assignments.js
@@ -62,10 +62,9 @@ const Assignments = (props) => {
 		retrieveAccountRoles(accountEntryId)
 			.then((response) => response.json())
 			.then(({items}) => {
-				const accountRoleItems = items.map(({displayName, name}) => {
+				const accountRoleItems = items.map(({name}) => {
 					return {
-						roleKey: name,
-						roleName: displayName,
+						roleName: name,
 						roleType: 'Account',
 					};
 				});
@@ -80,7 +79,6 @@ const Assignments = (props) => {
 				sectionsData.push({
 					autoCreate: assignments?.autoCreate?.[i],
 					identifier: `${Date.now()}-${i}`,
-					roleKey: assignments.roleKey[i],
 					roleName: assignments.roleName?.[i],
 					roleType: assignments.roleType[i],
 				});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/assignments/select-assignment/RoleType.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/assignments/select-assignment/RoleType.js
@@ -20,7 +20,6 @@ const RoleType = (props) => {
 				assignments: {
 					assignmentType: ['roleType'],
 					autoCreate: values.map(({autoCreate}) => autoCreate),
-					roleKey: values.map(({roleKey}) => roleKey),
 					roleName: values.map(({roleName}) => roleName),
 					roleType: values.map(({roleType}) => roleType),
 				},

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/notifications/NotificationsInfo.js
@@ -179,7 +179,6 @@ const NotificationsInfo = ({
 				...newRecipients[notificationIndex][0],
 				assignmentType: ['roleType'],
 				autoCreate: values.map(({autoCreate}) => autoCreate),
-				roleKey: values.map(({roleKey}) => roleKey),
 				roleName: values.map(({roleName}) => roleName),
 				roleType: values.map(({roleType}) => roleType),
 			};
@@ -433,7 +432,6 @@ const NotificationsInfo = ({
 				sectionsData.push({
 					autoCreate: recipients?.autoCreate?.[i],
 					identifier: `${Date.now()}-${i}`,
-					roleKey: recipients?.roleKey[i],
 					roleName: recipients?.roleName?.[i],
 					roleType: recipients?.roleType?.[i],
 				});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
@@ -185,10 +185,9 @@ const BaseNotificationsInfo = ({
 		retrieveAccountRoles(accountEntryId)
 			.then((response) => response.json())
 			.then(({items}) => {
-				const accountRoleItems = items.map(({displayName, name}) => {
+				const accountRoleItems = items.map(({name}) => {
 					return {
-						roleKey: name,
-						roleName: displayName,
+						roleName: name,
 						roleType: 'Account',
 					};
 				});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRoleType.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRoleType.js
@@ -21,7 +21,6 @@ const BaseRoleType = ({
 	inputLabel,
 	networkStatus,
 	resource,
-	roleKey,
 	roleName,
 	roleType = '',
 	sectionsLength,
@@ -34,9 +33,7 @@ const BaseRoleType = ({
 	const [filterRoleType, setFilterRoleType] = useState(true);
 	const [roleNameDropdownActive, setRoleNameDropdownActive] = useState(false);
 	const [roleTypeDropdownActive, setRoleTypeDropdownActive] = useState(false);
-	const [selectedRoleName, setSelectedRoleName] = useState(
-		roleName || roleKey
-	);
+	const [selectedRoleName, setSelectedRoleName] = useState(roleName);
 	const [selectedRoleType, setSelectedRoleType] = useState(
 		titleCase(roleType)
 	);
@@ -66,18 +63,17 @@ const BaseRoleType = ({
 
 	useEffect(() => {
 		setChecked(stringToBoolean(autoCreate));
-		setSelectedRoleName(roleName || roleKey);
+		setSelectedRoleName(roleName);
 		setSelectedRoleType(titleCase(roleType));
 
 		roleNameItemUpdate({
 			autoCreate,
-			roleKey,
 			roleName,
 			roleType: roleType.toLowerCase(),
 		});
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [autoCreate, roleKey, roleName, roleType]);
+	}, [autoCreate, roleName, roleType]);
 
 	const deleteSection = () => {
 		setSections((prevSections) => {
@@ -102,7 +98,6 @@ const BaseRoleType = ({
 			}
 
 			roles[roleType].push({
-				roleKey: item.externalReferenceCode,
 				roleName: item.name,
 				roleType,
 			});
@@ -261,9 +256,6 @@ const BaseRoleType = ({
 							if (selectedRoleName !== '') {
 								roleNameItemUpdate({
 									autoCreate: checked,
-									roleKey: filteredRoleNames().find(
-										(item) => item.roleName === roleName
-									).roleKey,
 									roleName,
 									roleType: selectedRoleType.toLowerCase(),
 								});
@@ -300,7 +292,6 @@ const BaseRoleType = ({
 										onMouseDown={() =>
 											roleNameItemUpdate({
 												autoCreate: checked,
-												roleKey: item.roleKey,
 												roleName: item.roleName,
 												roleType:
 													item.roleType.toLowerCase(),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/Timers.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/Timers.js
@@ -116,10 +116,6 @@ const Timers = ({setContentName, setErrors}) => {
 								filteredTimerActions[0].sectionData.map(
 									({autoCreate}) => autoCreate
 								);
-							reassignments.roleKey =
-								filteredTimerActions[0].sectionData.map(
-									({roleKey}) => roleKey
-								);
 							reassignments.roleName =
 								filteredTimerActions[0].sectionData.map(
 									({roleName}) => roleName
@@ -271,18 +267,17 @@ const Timers = ({setContentName, setErrors}) => {
 				}
 				else if (
 					section.assignmentType === 'roleType' &&
-					data.some((entry) => entry[0] === 'roleKey')
+					data.some((entry) => entry[0] === 'roleName')
 				) {
 					section.sectionData = data
-						.find((entry) => entry[0] === 'roleKey')[1]
-						.map((roleKey, index) => ({
+						.find((entry) => entry[0] === 'roleName')[1]
+						.map((index) => ({
 							autoCreate: filterSectionDataProperty(
 								data,
 								index,
 								'autoCreate'
 							),
 							identifier: `${Date.now()}-${index}`,
-							roleKey,
 							roleName: filterSectionDataProperty(
 								data,
 								index,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-action/ActionTypeNotification.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-action/ActionTypeNotification.js
@@ -135,7 +135,6 @@ const ActionTypeNotification = ({
 				recipients: {
 					assignmentType: ['roleType'],
 					autoCreate: values.map(({autoCreate}) => autoCreate),
-					roleKey: values.map(({roleKey}) => roleKey),
 					roleName: values.map(({roleName}) => roleName),
 					roleType: values.map(({roleType}) => roleType),
 				},
@@ -255,12 +254,11 @@ const ActionTypeNotification = ({
 		const recipients = actionData?.recipients;
 
 		if (recipients && recipientType === 'roleType') {
-			if (Array.isArray(recipients.roleKey)) {
-				for (let i = 0; i < recipients.roleKey.length; i++) {
+			if (Array.isArray(recipients.roleName)) {
+				for (let i = 0; i < recipients.roleName.length; i++) {
 					sectionsData.push({
 						autoCreate: recipients.autoCreate?.[i],
 						identifier: `${Date.now()}-${i}`,
-						roleKey: recipients.roleKey[i],
 						roleName: recipients.roleName?.[i],
 						roleType: recipients.roleType[i],
 					});
@@ -270,7 +268,6 @@ const ActionTypeNotification = ({
 				sectionsData.push({
 					autoCreate: recipients.autoCreate,
 					identifier: `${Date.now()}-0`,
-					roleKey: recipients.roleKey,
 					roleName: recipients.roleName?.[0],
 					roleType: recipients.roleType,
 				});

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
@@ -34,16 +34,15 @@ const RoleType = ({subSectionIdentifier, subSectionsLength, ...otherProps}) => {
 		},
 	});
 
-	const {autoCreate, roleKey, roleName, roleType} = otherProps?.restProps;
+	const {autoCreate, roleName, roleType} = otherProps?.restProps;
 
 	useEffect(() => {
 		retrieveAccountRoles(accountEntryId)
 			.then((response) => response.json())
 			.then(({items}) => {
-				const accountRoleItems = items.map(({displayName, name}) => {
+				const accountRoleItems = items.map(({name}) => {
 					return {
-						roleKey: name,
-						roleName: displayName,
+						roleName: name,
 						roleType: 'Account',
 					};
 				});
@@ -65,7 +64,6 @@ const RoleType = ({subSectionIdentifier, subSectionsLength, ...otherProps}) => {
 				inputLabel={Liferay.Language.get('role-type')}
 				networkStatus={networkStatus}
 				resource={resource}
-				roleKey={roleKey}
 				roleName={roleName}
 				roleType={roleType}
 				sectionsLength={subSectionsLength}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateAssignmentsData.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateAssignmentsData.js
@@ -106,11 +106,9 @@ const populateAssignmentsData = (
 					([roles, accountRoles]) => {
 						const items = roles.items.concat(accountRoles.items);
 
-						taskNode.data.assignments.roleKey.forEach((key) => {
+						taskNode.data.assignments.roleName.forEach((name) => {
 							const role = items.find(
-								(item) =>
-									item.externalReferenceCode === key ||
-									item.displayName === key
+								(item) => item.name === name
 							);
 
 							if (!taskNode.data.assignments.roleName) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
@@ -59,22 +59,20 @@ const populateNotificationsData = (
 									accountRoles.items
 								);
 
-								const roleKey =
+								const roleName =
 									element?.data?.notifications?.recipients[
 										index
-									]?.[0]?.roleKey;
+									]?.[0]?.roleName;
 
-								if (!roleKey) {
+								if (!roleName) {
 									return;
 								}
 
 								const roleNames = [];
 
-								roleKey.forEach((key) => {
+								roleName.forEach((name) => {
 									const role = items.find(
-										(item) =>
-											item.externalReferenceCode ===
-												key || item.displayName === key
+										(item) => item.name === name
 									);
 
 									if (
@@ -199,26 +197,24 @@ const populateNotificationsData = (
 									accountRoles.items
 								);
 
-								let roleKey =
+								let roleName =
 									element?.data?.taskTimers
 										?.timerNotifications[0]?.recipients[
 										index
-									]?.[0]?.roleKey;
+									]?.[0]?.roleName;
 
-								if (!roleKey) {
+								if (!roleName) {
 									return;
 								}
 
-								if (!Array.isArray(roleKey)) {
-									roleKey = [roleKey];
+								if (!Array.isArray(roleName)) {
+									roleName = [roleName];
 								}
 								const roleNames = [];
 
-								roleKey.forEach((key) => {
+								roleName.forEach((name) => {
 									const role = items.find(
-										(item) =>
-											item.externalReferenceCode ===
-												key || item.displayName === key
+										(item) => item.name === name
 									);
 
 									if (

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/serializeUtil.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/serializeUtil.js
@@ -207,14 +207,14 @@ function appendXMLAssignments(
 			const xmlRole = XMLUtil.createObj('role');
 
 			dataAssignments.roleType.forEach((item, index) => {
-				const roleKey = dataAssignments.roleKey[index];
+				const roleName = dataAssignments.roleName[index];
 				const roleType = dataAssignments.roleType[index];
 
-				if (roleKey) {
+				if (roleName) {
 					buffer.push(
 						xmlRole.open,
 						createTagWithEscapedContent('roleType', roleType),
-						createTagWithEscapedContent('name', roleKey)
+						createTagWithEscapedContent('name', roleName)
 					);
 
 					let autoCreate = dataAssignments.autoCreate?.[index];

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/utils.js
@@ -28,7 +28,7 @@ export function parseActions(node) {
 export function parseAssignments(node) {
 	const assignments = {};
 	const autoCreateValues = [];
-	const roleKeys = [];
+	const roleNames = [];
 	const roleTypes = [];
 	const users = [];
 	const typeUser = Object.keys(node.assignments[0])[0];
@@ -47,7 +47,7 @@ export function parseAssignments(node) {
 		else if (itemKeys.includes('role-type')) {
 			assignments.assignmentType = ['roleType'];
 			autoCreateValues.push(item['auto-create']);
-			roleKeys.push(item.name);
+			roleNames.push(item.name);
 			roleTypes.push(item['role-type']);
 		}
 		else if (itemKeys.includes('script')) {
@@ -86,7 +86,7 @@ export function parseAssignments(node) {
 
 	if (assignments.assignmentType[0] === 'roleType') {
 		assignments.autoCreate = autoCreateValues[0];
-		assignments.roleKey = roleKeys[0];
+		assignments.roleName = roleNames[0];
 		assignments.roleType = roleTypes[0];
 	}
 
@@ -107,14 +107,14 @@ export function parseReassignments(node) {
 				assignments.assignmentType = ['roleType'];
 
 				assignments.autoCreate = [];
-				assignments.roleKey = [];
+				assignments.roleName = [];
 				assignments.roleType = [];
 
 				for (let index = 0; index < item['roles']?.length; index++) {
 					assignments.autoCreate.push(
 						item['roles'][index]?.['role']?.['auto-create']
 					);
-					assignments.roleKey.push(
+					assignments.roleName.push(
 						item['roles'][index]?.['role']?.['name']
 					);
 					assignments.roleType.push(
@@ -357,7 +357,7 @@ export function parseNotifications(node) {
 			const autoCreate =
 				item['auto-create'] ||
 				item['recipients'][0]['roles']['auto-create'];
-			const roleKey =
+			const roleName =
 				item['role-name'] || item['recipients'][0]['roles']['name'];
 			const roleType =
 				item['role-type'] ||
@@ -368,7 +368,7 @@ export function parseNotifications(node) {
 					assignmentType: ['roleType'],
 					autoCreate,
 					receptionType: [receptionType],
-					roleKey,
+					roleName,
 					roleType,
 				});
 			}
@@ -376,7 +376,7 @@ export function parseNotifications(node) {
 				notifications.recipients[index].push({
 					assignmentType: ['roleType'],
 					autoCreate,
-					roleKey,
+					roleName,
 					roleType,
 				});
 			}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Permissions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Permissions.macro
@@ -188,7 +188,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = ${userEmailAddress});
 
-		JSONRole.addRegularRole(roleTitle = ${roleTitle});
+		JSONRole.addRegularRole(roleKey = ${roleTitle});
 
 		JSONRole.assignRoleToUser(
 			roleTitle = ${roleTitle},
@@ -253,7 +253,7 @@ definition {
 			userEmailAddress = ${userEmailAddress},
 			userScreenName = ${userScreenName});
 
-		JSONRole.addRegularRole(roleTitle = ${roleTitle});
+		JSONRole.addRegularRole(roleKey = ${roleTitle});
 
 		JSONRole.assignRoleToUser(
 			roleTitle = ${roleTitle},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
@@ -37,8 +37,8 @@ definition {
 		Variables.assertDefined(parameterList = ${roleTitle});
 
 		var descriptionMap = JSONRoleSetter.setDescriptionMap(description = ${roleDescription});
-		var name = JSONRoleSetter.setName(name = ${roleTitle});
-		var titleMap = JSONRoleSetter.setTitleMap(title = ${roleKey});
+		var name = JSONRoleSetter.setName(name = ${roleKey});
+		var titleMap = JSONRoleSetter.setTitleMap(title = ${roleTitle});
 		var type = JSONRoleSetter.setType(roleType = "regular");
 
 		JSONRoleAPI._addRole(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
@@ -34,7 +34,7 @@ definition {
 
 	@summary = "Default summary"
 	macro addRegularRole(roleTitle = null, roleKey = null, specificURL = null, roleDescription = null) {
-		Variables.assertDefined(parameterList = ${roleTitle});
+		Variables.assertDefined(parameterList = ${roleKey});
 
 		var descriptionMap = JSONRoleSetter.setDescriptionMap(description = ${roleDescription});
 		var name = JSONRoleSetter.setName(name = ${roleKey});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleTest.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleTest.macro
@@ -7,7 +7,7 @@ definition {
 
 		JSONRole.addOrganizationRole(roleTitle = "organization role");
 
-		JSONRole.addRegularRole(roleTitle = "regular role");
+		JSONRole.addRegularRole(roleKey = "regular role");
 
 		JSONRole.addSiteRole(roleTitle = "site role");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/site/SiteTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/site/SiteTemplates.macro
@@ -504,7 +504,7 @@ definition {
 				roleTitle = "Access Site");
 		}
 		else {
-			JSONRole.addRegularRole(roleTitle = "Access Site");
+			JSONRole.addRegularRole(roleKey = "Access Site");
 		}
 
 		Permissions.definePermissionViaJSONAPI(
@@ -536,7 +536,7 @@ definition {
 
 	@summary = "Default summary"
 	macro grantUserAccessToSiteTemplates(userEmailAddress = null) {
-		JSONRole.addRegularRole(roleTitle = "Access Site Templates");
+		JSONRole.addRegularRole(roleKey = "Access Site Templates");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ACCESS_IN_CONTROL_PANEL",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/VirtualInstances.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/VirtualInstances.testcase
@@ -111,7 +111,7 @@ definition {
 
 		task ("And given a user exists in that instance with permission to create other users") {
 			JSONRole.addRegularRole(
-				roleTitle = "Test Role",
+				roleKey = "Test Role",
 				specificURL = "http://www.able.com:8080");
 
 			Permissions.definePermissionsViaJSONAPI(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdmin.testcase
@@ -1893,7 +1893,7 @@ definition {
 
 		var siteName = TestCase.getSiteName(siteName = ${siteName});
 
-		JSONRole.addRegularRole(roleTitle = "Impersonating Role Name");
+		JSONRole.addRegularRole(roleKey = "Impersonating Role Name");
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "VIEW_CONTROL_PANEL",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdminPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdminPermissions.testcase
@@ -131,7 +131,7 @@ definition {
 		}
 
 		task ("And given the first user is assigned to a new regular role with permissions to update and view users") {
-			JSONRole.addRegularRole(roleTitle = "New Regular Role");
+			JSONRole.addRegularRole(roleKey = "New Regular Role");
 
 			JSONRole.assignRoleToUser(
 				roleTitle = "New Regular Role",
@@ -190,7 +190,7 @@ definition {
 				userLastName = "userln",
 				userScreenName = "usersn");
 
-			JSONRole.addRegularRole(roleTitle = "New Regular Role");
+			JSONRole.addRegularRole(roleKey = "New Regular Role");
 
 			JSONRole.assignRoleToUser(
 				roleTitle = "New Regular Role",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPermissions.testcase
@@ -120,7 +120,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Test Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Test Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Test Regrole Name",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsPermissions.testcase
@@ -31,7 +31,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Test Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Test Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Test Regrole Name",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
@@ -1350,7 +1350,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = "userea@liferay.com");
 
-		JSONRole.addRegularRole(roleTitle = "Depot Regrole Name");
+		JSONRole.addRegularRole(roleKey = "Depot Regrole Name");
 
 		JSONRole.assignRoleToUser(
 			roleTitle = "Depot Regrole Name",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
@@ -51,7 +51,7 @@ definition {
 		var randomRoleKey = StringUtil.randomString(8);
 
 		task ("Given the site administrator enables the Show Control Menu by Role") {
-			JSONRole.addRegularRole(roleTitle = ${randomRoleKey});
+			JSONRole.addRegularRole(roleKey = ${randomRoleKey});
 
 			Permissions.definePermissionViaJSONAPI(
 				resourceAction = "VIEW_SITE_ADMINISTRATION",
@@ -223,7 +223,7 @@ definition {
 		var randomRoleKey = StringUtil.randomString(8);
 
 		task ("Given the site administrator enables the Show Control Menu by Role") {
-			JSONRole.addRegularRole(roleTitle = ${randomRoleKey});
+			JSONRole.addRegularRole(roleKey = ${randomRoleKey});
 
 			Permissions.definePermissionViaJSONAPI(
 				resourceAction = "ACCESS_IN_CONTROL_PANEL",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FormFragments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FormFragments.testcase
@@ -579,7 +579,7 @@ definition {
 				groupName = "Test Site Name",
 				userEmailAddress = "userea@liferay.com");
 
-			JSONRole.addRegularRole(roleTitle = "Regular Role Name");
+			JSONRole.addRegularRole(roleKey = "Regular Role Name");
 
 			Permissions.definePermissionViaJSONAPI(
 				resourceAction = "UPDATE",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/CPRolesCPWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/CPRolesCPWebcontent.testcase
@@ -403,7 +403,7 @@ definition {
 			requireReset = "false",
 			userEmailAddress = StringUtil.toLowerCase("${userEmailAddress}@liferay.com"));
 
-		JSONRole.addRegularRole(roleTitle = ${roleKey});
+		JSONRole.addRegularRole(roleKey = ${roleKey});
 
 		JSONRole.assignRoleToUser(
 			roleTitle = ${roleKey},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/widgetpage/PageCustomizations.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/widgetpage/PageCustomizations.testcase
@@ -123,7 +123,7 @@ definition {
 		}
 
 		task ("Add a new regular role") {
-			JSONRole.addRegularRole(roleTitle = ${roleKey});
+			JSONRole.addRegularRole(roleKey = ${roleKey});
 		}
 
 		task ("Define the permissions of new role") {
@@ -266,7 +266,7 @@ definition {
 		}
 
 		task ("Add a new regular role") {
-			JSONRole.addRegularRole(roleTitle = ${roleKey});
+			JSONRole.addRegularRole(roleKey = ${roleKey});
 		}
 
 		task ("Define the permissions of new role") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/CPRolesCPSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/CPRolesCPSites.testcase
@@ -54,7 +54,7 @@ definition {
 		}
 
 		task ("Add a new regular role") {
-			JSONRole.addRegularRole(roleTitle = ${randomRoleKey});
+			JSONRole.addRegularRole(roleKey = ${randomRoleKey});
 		}
 	}
 


### PR DESCRIPTION
Related [bug](https://liferay.atlassian.net/browse/LPD-33901) - Release blocker

After a [change](https://github.com/brianchandotcom/liferay-portal/pull/153052/files#diff-97219d8219276d8f05d1a198731ff6fd5d3230ef7c99e858c65d8a5c7d7b342eR77) in the role API return, the FE of the process builder, which previously used the [role key disguised as an external reference code](https://github.com/liferay/liferay-portal/blob/e69f21c3db55287fe5511bcadf6fd34cdfb5e5d3/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRoleType.js#L105), started adding role externalReferenceCode values ​​in the workflow definition XML, where the role name values ​​should be added.

As a proposed solution, I modified the role API to return the name value in the name field instead of the title, since the name value was no longer being returned.

Now we just use the term role name in the process builder FE, since the role key is just an abstraction of the role name.

For the `RoleNameContainingMultibyteCharactersCanBeUsedInWorkflow` poshi test to be corrected and continue to make sense, some changes needed to be made.

Changes not related to the process builder will be reviewed in the commerce repository