### PR TITLE
LPD-34235 Use the httpServletRequest before it gets recycled

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -21,7 +21,10 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.ServiceContextContributor;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
@@ -36,7 +39,6 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletResponse;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -87,19 +89,20 @@ public class CompleteTaskMVCActionCommand
 			ServiceContext serviceContext = (ServiceContext)workflowContext.get(
 				WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
 
-			HttpServletRequest httpServletRequest = _getHttpServletRequest(
-				actionRequest, actionResponse);
+			serviceContext.setRequest(
+				_getHttpServletRequest(actionRequest, actionResponse));
 
-			serviceContext.setAttribute(
-				"serverName", httpServletRequest.getServerName());
-			serviceContext.setAttribute(
-				"serverPort", httpServletRequest.getServerPort());
+			WorkflowHandler<?> workflowHandler =
+				WorkflowHandlerRegistryUtil.getWorkflowHandler(
+					(String)workflowContext.get(
+						WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
 
-			HttpSession httpSession = httpServletRequest.getSession();
+			if (workflowHandler instanceof ServiceContextContributor) {
+				ServiceContextContributor serviceContextContributor =
+					(ServiceContextContributor)workflowHandler;
 
-			serviceContext.setAttribute("sessionId", httpSession.getId());
-
-			serviceContext.setRequest(httpServletRequest);
+				serviceContextContributor.contribute(serviceContext);
+			}
 
 			workflowContext.put(
 				WorkflowConstants.CONTEXT_USER_ID,

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/workflow/UserWorkflowHandler.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
+import com.liferay.portal.kernel.workflow.ServiceContextContributor;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
 
@@ -20,6 +21,9 @@ import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -31,7 +35,24 @@ import org.osgi.service.component.annotations.Reference;
 	property = "model.class.name=com.liferay.portal.kernel.model.User",
 	service = WorkflowHandler.class
 )
-public class UserWorkflowHandler extends BaseWorkflowHandler<User> {
+public class UserWorkflowHandler
+	extends BaseWorkflowHandler<User> implements ServiceContextContributor {
+
+	@Override
+	public void contribute(ServiceContext serviceContext) {
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		serviceContext.setAttribute(
+			"serverName", httpServletRequest.getServerName());
+		serviceContext.setAttribute(
+			"serverPort", httpServletRequest.getServerPort());
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		serviceContext.setAttribute("sessionId", httpSession.getId());
+
+		serviceContext.setRequest(httpServletRequest);
+	}
 
 	@Override
 	public String getClassName() {

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -40,12 +40,10 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
-import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -149,6 +147,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import javax.portlet.PortletRequest;
@@ -2375,46 +2374,41 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	}
 
 	private String _getDiffsURL(
-			WikiPage page, WikiPage previousVersionPage,
-			ServiceContext serviceContext)
-		throws PortalException {
+		WikiPage page, WikiPage previousVersionPage,
+		ServiceContext serviceContext) {
 
 		if (previousVersionPage == null) {
 			return StringPool.BLANK;
 		}
 
-		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+		String baseDiffsURL = (String)serviceContext.getAttribute(
+			"baseDiffsURL");
 
-		if (httpServletRequest == null) {
+		if (baseDiffsURL == null) {
 			return StringPool.BLANK;
 		}
 
-		PortletURL portletURL = null;
+		StringBundler sb = new StringBundler(6);
 
-		long plid = serviceContext.getPlid();
+		sb.append(baseDiffsURL);
 
-		if (plid == LayoutConstants.DEFAULT_PLID) {
-			portletURL = _portal.getControlPanelPortletURL(
-				httpServletRequest, WikiPortletKeys.WIKI_ADMIN,
-				PortletRequest.RENDER_PHASE);
-		}
-		else {
-			portletURL = _portletURLFactory.create(
-				httpServletRequest, WikiPortletKeys.WIKI, plid,
-				PortletRequest.RENDER_PHASE);
-		}
+		BiConsumer<String, String> biConsumer = (name, value) -> {
+			sb.append(serviceContext.getPortletId());
+			sb.append(StringPool.UNDERLINE);
+			sb.append(URLCodec.encodeURL(name));
+			sb.append(StringPool.EQUAL);
+			sb.append(URLCodec.encodeURL(value));
+		};
 
-		portletURL.setParameter(
-			"mvcRenderCommandName", "/wiki/compare_versions");
-		portletURL.setParameter("nodeId", String.valueOf(page.getNodeId()));
-		portletURL.setParameter("title", page.getTitle());
-		portletURL.setParameter(
-			"sourceVersion", String.valueOf(previousVersionPage.getVersion()));
-		portletURL.setParameter(
-			"targetVersion", String.valueOf(page.getVersion()));
-		portletURL.setParameter("type", "html");
+		biConsumer.accept("&mvcRenderCommandName", "/wiki/compare_versions");
+		biConsumer.accept("&nodeId", String.valueOf(page.getNodeId()));
+		biConsumer.accept(
+			"&sourceVersion", String.valueOf(previousVersionPage.getVersion()));
+		biConsumer.accept("&targetVersion", String.valueOf(page.getVersion()));
+		biConsumer.accept("&title", page.getTitle());
+		biConsumer.accept("&type", "html");
 
-		return portletURL.toString();
+		return sb.toString();
 	}
 
 	private Map<String, Boolean> _getOutgoingLinks(WikiPage page)
@@ -3530,9 +3524,6 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;
-
-	@Reference
-	private PortletURLFactory _portletURLFactory;
 
 	@Reference
 	private RatingsStatsLocalService _ratingsStatsLocalService;

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
@@ -6,12 +6,17 @@
 package com.liferay.wiki.web.internal.workflow;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
+import com.liferay.portal.kernel.workflow.ServiceContextContributor;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiPageLocalService;
 
@@ -19,6 +24,11 @@ import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -31,7 +41,29 @@ import org.osgi.service.component.annotations.Reference;
 	property = "model.class.name=com.liferay.wiki.model.WikiPage",
 	service = WorkflowHandler.class
 )
-public class WikiPageWorkflowHandler extends BaseWorkflowHandler<WikiPage> {
+public class WikiPageWorkflowHandler
+	extends BaseWorkflowHandler<WikiPage> implements ServiceContextContributor {
+
+	@Override
+	public void contribute(ServiceContext serviceContext) {
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		PortletURL portletURL = null;
+		long plid = serviceContext.getPlid();
+
+		if (plid == LayoutConstants.DEFAULT_PLID) {
+			portletURL = _portal.getControlPanelPortletURL(
+				httpServletRequest, WikiPortletKeys.WIKI_ADMIN,
+				PortletRequest.RENDER_PHASE);
+		}
+		else {
+			portletURL = _portletURLFactory.create(
+				httpServletRequest, WikiPortletKeys.WIKI, plid,
+				PortletRequest.RENDER_PHASE);
+		}
+
+		serviceContext.setAttribute("baseDiffsURL", portletURL.toString());
+	}
 
 	@Override
 	public String getClassName() {
@@ -72,6 +104,12 @@ public class WikiPageWorkflowHandler extends BaseWorkflowHandler<WikiPage> {
 		return _wikiPageLocalService.updateStatus(
 			userId, page, status, serviceContext, workflowContext);
 	}
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private PortletURLFactory _portletURLFactory;
 
 	@Reference
 	private WikiPageLocalService _wikiPageLocalService;

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/ServiceContextContributor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/ServiceContextContributor.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.workflow;
+
+import com.liferay.portal.kernel.service.ServiceContext;
+
+/**
+ * @author Feliphe Marinho
+ */
+public interface ServiceContextContributor {
+
+	public void contribute(ServiceContext serviceContext);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 21.1.0
+version 21.2.0


### PR DESCRIPTION
## Related tickets

- https://liferay.atlassian.net/browse/LPD-34235

## Motivation

_"java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade"_ is being thrown at [WikiPageLocalServiceImpl._getDiffsURL](https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java#L2396-L2405), at this moment the request is already recycled due to the asynchronicity of workflow graph walker.

## Proposed Solution

Fetch the data before the request is recycled instead of forcing this operation to be synchronous by passing the `waitForCompletion` as true.

## Test

`WorkflowWiki#ApproveFrontPageUserEdit` is already covering this use case

## Related

- https://github.com/brianchandotcom/liferay-portal/pull/152869
